### PR TITLE
Add Solar/Grid/Load energy sensors for HA Energy Dashboard

### DIFF
--- a/custom_components/emaldo/__init__.py
+++ b/custom_components/emaldo/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .coordinator import EmaldoCoordinator
+from .coordinator import EmaldoCoordinator, EmaldoRealtimeCoordinator
 from .schedule_coordinator import EmaldoScheduleCoordinator
 from .services import async_register_services, async_unregister_services
 
@@ -19,12 +19,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     power_coordinator = EmaldoCoordinator(hass, entry)
     await power_coordinator.async_config_entry_first_refresh()
 
+    realtime_coordinator = EmaldoRealtimeCoordinator(hass, entry, power_coordinator)
+    # Best-effort first refresh — if E2E fails, keep the integration working
+    # with the slower REST power data.
+    try:
+        await realtime_coordinator.async_config_entry_first_refresh()
+    except Exception:  # noqa: BLE001
+        pass
+
     schedule_coordinator = EmaldoScheduleCoordinator(hass, entry)
     await schedule_coordinator.async_config_entry_first_refresh()
     schedule_coordinator.async_setup_listeners()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "power": power_coordinator,
+        "realtime": realtime_coordinator,
         "schedule": schedule_coordinator,
     }
 
@@ -52,6 +61,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data = hass.data[DOMAIN].pop(entry.entry_id)
         data["schedule"].async_shutdown()
+        await data["realtime"].async_shutdown()
         if not hass.data[DOMAIN]:
             async_unregister_services(hass)
     return unload_ok

--- a/custom_components/emaldo/const.py
+++ b/custom_components/emaldo/const.py
@@ -7,7 +7,9 @@ CONF_APP_ID = "app_id"
 CONF_APP_SECRET = "app_secret"
 CONF_APP_VERSION = "app_version"
 
-DEFAULT_SCAN_INTERVAL = 60  # seconds
+DEFAULT_SCAN_INTERVAL = 60  # seconds (REST battery + power)
+REALTIME_SCAN_INTERVAL = 10  # seconds (E2E power flow, persistent session)
+KEEPALIVE_INTERVAL = 15  # seconds (E2E relay session keepalive)
 
 # Schedule polling configuration
 CONF_SCHEDULE_START_HOUR = "schedule_start_hour"

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -1,7 +1,14 @@
-"""DataUpdateCoordinator for Emaldo."""
+"""DataUpdateCoordinators for Emaldo.
+
+Two coordinators:
+* :class:`EmaldoCoordinator` — slow REST + battery details (60s interval)
+* :class:`EmaldoRealtimeCoordinator` — fast E2E power flow via a persistent
+  UDP session (10s interval).
+"""
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -11,7 +18,12 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .emaldo_lib import EmaldoClient, EmaldoAuthError, EmaldoConnectionError
+from .emaldo_lib import (
+    EmaldoClient,
+    EmaldoAuthError,
+    EmaldoConnectionError,
+    PersistentE2ESession,
+)
 from .emaldo_lib.const import set_params
 
 from .const import (
@@ -21,13 +33,15 @@ from .const import (
     CONF_APP_SECRET,
     CONF_APP_VERSION,
     DEFAULT_SCAN_INTERVAL,
+    REALTIME_SCAN_INTERVAL,
+    KEEPALIVE_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator to poll Emaldo API."""
+    """Slow coordinator for REST battery/power data (60s)."""
 
     config_entry: ConfigEntry
 
@@ -85,7 +99,7 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self._client
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from Emaldo API."""
+        """Fetch battery + power data from the REST API."""
         for attempt in range(2):
             try:
                 client = await self.hass.async_add_executor_job(self._ensure_client)
@@ -107,18 +121,160 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as err:
                 raise UpdateFailed(f"Error fetching Emaldo data: {err}") from err
 
-        # E2E power flow (best-effort, don't fail the whole update)
-        power_flow = None
-        try:
-            power_flow = await self.hass.async_add_executor_job(
-                client.get_power_flow,
-                self.home_id, self._device_id, self._model,
-            )
-        except Exception as err:
-            _LOGGER.debug("E2E power flow read failed: %s", err)
-
         return {
             "battery": battery,
             "power": power,
-            "power_flow": power_flow,
         }
+
+
+class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
+    """Fast coordinator for E2E real-time power flow (10s).
+
+    Uses :class:`PersistentE2ESession` to keep a UDP socket open across polls,
+    reducing latency from ~500ms to ~85ms per read. A background task sends
+    keepalive messages every 15 seconds to prevent the relay server from
+    dropping the session.
+    """
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        parent: EmaldoCoordinator,
+    ) -> None:
+        """Initialize the realtime coordinator.
+
+        Args:
+            hass: Home Assistant instance.
+            entry: Config entry.
+            parent: The slow :class:`EmaldoCoordinator` — used to share the
+                authenticated REST client and device discovery.
+        """
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_realtime",
+            update_interval=timedelta(seconds=REALTIME_SCAN_INTERVAL),
+        )
+        self._entry = entry
+        self._parent = parent
+        self._session: PersistentE2ESession | None = None
+        self._keepalive_task: asyncio.Task | None = None
+
+    # -- Proxy properties so sensors can share one class across coordinators --
+
+    @property
+    def home_id(self) -> str:
+        return self._parent.home_id
+
+    @property
+    def device_id(self) -> str | None:
+        return self._parent.device_id
+
+    @property
+    def device_model(self) -> str | None:
+        return self._parent.device_model
+
+    @property
+    def device_name(self) -> str | None:
+        return self._parent.device_name
+
+    async def async_shutdown(self) -> None:
+        """Cancel keepalive and close the UDP session."""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._keepalive_task = None
+        if self._session is not None:
+            await self.hass.async_add_executor_job(self._session.close)
+            self._session = None
+
+    def _ensure_session(self) -> PersistentE2ESession:
+        """Create and connect the persistent E2E session if needed."""
+        if self._session is not None and not self._session.closed:
+            return self._session
+
+        client = self._parent._ensure_client()  # noqa: SLF001 - intended
+        home_id = self._parent.home_id
+        device_id = self._parent._device_id  # noqa: SLF001
+        model = self._parent._model  # noqa: SLF001
+        if device_id is None or model is None:
+            raise UpdateFailed("Device not yet discovered")
+
+        creds = client.e2e_login(home_id, device_id, model)
+        self._session = PersistentE2ESession(creds)
+        self._session.connect()
+        return self._session
+
+    def _read_power_flow(self) -> dict | None:
+        """Synchronous helper that runs in the executor."""
+        session = self._ensure_session()
+        data = session.read_power_flow()
+        if data is None and session.closed:
+            # Session died mid-read — force recreation on next call
+            self._session = None
+        return data
+
+    async def _async_update_data(self) -> dict[str, Any] | None:
+        """Fetch realtime power flow via the persistent E2E session."""
+        try:
+            data = await self.hass.async_add_executor_job(self._read_power_flow)
+        except EmaldoAuthError as err:
+            # Token expired — force REST re-login and E2E reconnect
+            self._parent._client = None  # noqa: SLF001
+            await self._close_session()
+            raise UpdateFailed(f"E2E auth failed: {err}") from err
+        except Exception as err:
+            await self._close_session()
+            raise UpdateFailed(f"E2E power flow read failed: {err}") from err
+
+        if data is None:
+            await self._close_session()
+            raise UpdateFailed("No power flow data returned")
+
+        # Ensure keepalive task is running
+        if self._keepalive_task is None or self._keepalive_task.done():
+            self._keepalive_task = self.hass.async_create_task(
+                self._keepalive_loop(), name=f"{DOMAIN}_keepalive"
+            )
+
+        return data
+
+    async def _close_session(self) -> None:
+        """Close the current session (if any)."""
+        if self._session is not None:
+            try:
+                await self.hass.async_add_executor_job(self._session.close)
+            except Exception:  # noqa: BLE001
+                pass
+            self._session = None
+
+    async def _keepalive_loop(self) -> None:
+        """Periodically send alive+heartbeat to keep the relay session alive."""
+        fail_count = 0
+        try:
+            while True:
+                await asyncio.sleep(KEEPALIVE_INTERVAL)
+                if self._session is None or self._session.closed:
+                    return
+                try:
+                    ok = await self.hass.async_add_executor_job(self._session.keepalive)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug("Keepalive error: %s", err)
+                    ok = False
+                if ok:
+                    fail_count = 0
+                else:
+                    fail_count += 1
+                    _LOGGER.debug("Keepalive fail #%d", fail_count)
+                    if fail_count >= 2:
+                        _LOGGER.info("Keepalive failed twice, closing session for reconnect")
+                        await self._close_session()
+                        return
+        except asyncio.CancelledError:
+            pass

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -121,9 +121,19 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as err:
                 raise UpdateFailed(f"Error fetching Emaldo data: {err}") from err
 
+        # Solar MPPT stats — best-effort, not all devices have solar
+        solar = None
+        try:
+            solar = await self.hass.async_add_executor_job(
+                client.get_solar, self.home_id, self._device_id, self._model
+            )
+        except Exception as err:
+            _LOGGER.debug("Solar stats fetch failed: %s", err)
+
         return {
             "battery": battery,
             "power": power,
+            "solar": solar,
         }
 
 

--- a/custom_components/emaldo/emaldo_lib/__init__.py
+++ b/custom_components/emaldo/emaldo_lib/__init__.py
@@ -1,6 +1,14 @@
 """Emaldo battery system API client (bundled for HA integration)."""
 
 from .client import EmaldoClient
+from .e2e import PersistentE2ESession
 from .exceptions import EmaldoError, EmaldoAuthError, EmaldoAPIError, EmaldoConnectionError
 
-__all__ = ["EmaldoClient", "EmaldoError", "EmaldoAuthError", "EmaldoAPIError", "EmaldoConnectionError"]
+__all__ = [
+    "EmaldoClient",
+    "PersistentE2ESession",
+    "EmaldoError",
+    "EmaldoAuthError",
+    "EmaldoAPIError",
+    "EmaldoConnectionError",
+]

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -1,6 +1,7 @@
 """E2E (UDP) protocol for direct device communication.
 
-Used for reading and writing charge/discharge override schedules.
+Used for reading and writing charge/discharge override schedules
+and for retrieving realtime power flow data directly from the device.
 The protocol uses AES-256-CBC encryption over UDP.
 """
 
@@ -466,14 +467,18 @@ def parse_battery_data(payload: bytes) -> dict | None:
 def _is_power_flow_payload(payload: bytes) -> bool:
     """Check if decrypted payload looks like a power flow response.
 
-    Power flow responses are 16-24 bytes of signed-short watt values.
+    Power flow responses are 16–24 bytes of signed-short watt values.
+    Heuristic: correct length range, reasonable watt values, and
+    boolean flags at bytes 16–17 must be 0 or 1.
     """
     if len(payload) < 16 or len(payload) > 24:
         return False
+    # First two shorts should be reasonable watt values
     battery_w = struct.unpack_from("<h", payload, 0)[0]
     solar_w = struct.unpack_from("<h", payload, 2)[0]
     if abs(battery_w) >= 30000 or abs(solar_w) >= 30000:
         return False
+    # Bytes 16–17 are boolean flags (gridValid, bsensorValid)
     if len(payload) >= 18:
         if payload[16] not in (0, 1) or payload[17] not in (0, 1):
             return False
@@ -483,7 +488,37 @@ def _is_power_flow_payload(payload: bytes) -> bool:
 def parse_power_flow(payload: bytes) -> dict | None:
     """Parse a type 0x30 power-flow response payload.
 
-    Returns a dict with battery_w, solar_w, grid_w, dual_power_w, etc.
+    This is the ``GET_GLOBAL_CURRENT_FLOW_INFO`` command response.
+    The app screen calls it "Realtime Power".
+
+    Payload layout (16–22 bytes, little-endian):
+
+    ======  ====  ======================  ================================
+    Offset  Size  Field                   Description
+    ======  ====  ======================  ================================
+    0-1     2     battery_w               signed short – battery power
+                                          (hectowatts, ×100 = W).
+                                          positive = charging,
+                                          negative = discharging
+    2-3     2     solar_w                 signed short – solar/PV power
+    4-5     2     grid_w                  signed short – grid power
+                                          positive = importing,
+                                          negative = exporting
+    6-7     2     addition_load_w         signed short – additional load
+    8-9     2     other_load_w            signed short – other load
+    10-11   2     ev_w                    signed short – EV charger
+    12-13   2     ip2_w                   unsigned short – input port 2
+    14-15   2     op2_w                   unsigned short – output port 2
+    16      1     grid_valid              bool – grid CT sensor present
+    17      1     bsensor_valid           bool – battery sensor present
+    18      1     solar_efficiency        enum – solar efficiency type
+    19      1     thirdparty_pv_on        bool – 3rd-party PV enabled
+    20-21   2     dual_power_w            signed short – household +
+                                          solar combined (W)
+    ======  ====  ======================  ================================
+
+    Returns:
+        Dict with decoded power flow values, or *None* if invalid.
     """
     if payload is None or len(payload) < 16:
         return None
@@ -499,10 +534,12 @@ def parse_power_flow(payload: bytes) -> dict | None:
     ip2_w = struct.unpack_from("<H", payload, 12)[0] * _scale
     op2_w = struct.unpack_from("<H", payload, 14)[0] * _scale
 
+    # Extended fields (bytes 16-21) may be absent in older firmware
     length = len(payload)
     max_len = max(length, 22)
     buf = bytearray(max_len)
     buf[:length] = payload
+    # Pad missing bytes with defaults (match Java logic)
     for i in range(length, max_len):
         buf[i] = 1 if i in (16, 17) else 0
 
@@ -803,6 +840,124 @@ def read_battery_info(
                     break
 
         return batteries
+    finally:
+        sock.close()
+
+
+def _log_power_flow_raw(payload: bytes, log: Callable[..., None]) -> None:
+    """Dump raw power flow payload for debugging."""
+    log(f"Raw payload ({len(payload)}B): {payload.hex()}")
+    if len(payload) >= 2:
+        log(f"  [0:2]   batteryWat      = {struct.unpack_from('<h', payload, 0)[0]}")
+    if len(payload) >= 4:
+        log(f"  [2:4]   solarWat        = {struct.unpack_from('<h', payload, 2)[0]}")
+    if len(payload) >= 6:
+        log(f"  [4:6]   gridWat         = {struct.unpack_from('<h', payload, 4)[0]}")
+    if len(payload) >= 8:
+        log(f"  [6:8]   additionLoadWat = {struct.unpack_from('<h', payload, 6)[0]}")
+    if len(payload) >= 10:
+        log(f"  [8:10]  otherLoadWat    = {struct.unpack_from('<h', payload, 8)[0]}")
+    if len(payload) >= 12:
+        log(f"  [10:12] vechiWat        = {struct.unpack_from('<h', payload, 10)[0]}")
+    if len(payload) >= 14:
+        log(f"  [12:14] ip2Wat          = {struct.unpack_from('<H', payload, 12)[0]}")
+    if len(payload) >= 16:
+        log(f"  [14:16] op2Wat          = {struct.unpack_from('<H', payload, 14)[0]}")
+    if len(payload) >= 17:
+        log(f"  [16]    gridValid       = {payload[16]}")
+    if len(payload) >= 18:
+        log(f"  [17]    bsensorValid    = {payload[17]}")
+    if len(payload) >= 19:
+        log(f"  [18]    solarEfficiency = {payload[18]}")
+    if len(payload) >= 20:
+        log(f"  [19]    thirdpartyPVOn  = {payload[19]}")
+    if len(payload) >= 22:
+        log(f"  [20:22] dualPowerWat    = {struct.unpack_from('<h', payload, 20)[0]}")
+
+
+def read_power_flow(
+    e2e_creds: dict,
+    *,
+    timeout: float = 5.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read realtime power flow via E2E (type 0x30).
+
+    Sends ``GET_GLOBAL_CURRENT_FLOW_INFO`` and returns a dict with
+    ``battery_w``, ``solar_w``, ``grid_w``, ``dual_power_w``, etc.
+    Returns *None* on failure.
+    """
+    session_nonce = generate_nonce()
+
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    power_pkt = build_subscription_packet(
+        e2e_creds, 0x30, session_nonce, payload=bytes([0x01]),
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if log:
+                log(f"{label}: sent {len(pkt)}B → no response")
+            return None
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+
+        resp = _send(power_pkt, "PowerFlow(0x30)")
+        if not resp:
+            return None
+
+        decrypted = decrypt_response(
+            resp, e2e_creds["chat_secret"],
+            payload_validator=_is_power_flow_payload,
+        )
+        if decrypted is not None and log:
+            _log_power_flow_raw(decrypted, log)
+        result = parse_power_flow(decrypted)
+        if result is not None:
+            return result
+
+        # First response may be an echo/ACK; try a few more
+        for _ in range(5):
+            try:
+                resp, _ = sock.recvfrom(4096)
+                decrypted = decrypt_response(
+                    resp, e2e_creds["chat_secret"],
+                    payload_validator=_is_power_flow_payload,
+                )
+                if decrypted is not None and log:
+                    _log_power_flow_raw(decrypted, log)
+                result = parse_power_flow(decrypted)
+                if result is not None:
+                    return result
+            except socket.timeout:
+                break
+
+        return None
     finally:
         sock.close()
 
@@ -1279,83 +1434,265 @@ def set_peak_shaving_redundancy(
     return resp is not None
 
 
-def read_power_flow(
-    e2e_creds: dict,
-    *,
-    timeout: float = 5.0,
-    log: Callable[..., None] | None = None,
-) -> dict | None:
-    """Read realtime power flow via E2E (type 0x30).
+# ---------------------------------------------------------------------------
+# Persistent E2E Session (for real-time polling)
+# ---------------------------------------------------------------------------
 
-    Returns a dict with battery_w, solar_w, grid_w, dual_power_w, etc.
-    Returns None on failure.
-    """
-    session_nonce = generate_nonce()
+class PersistentE2ESession:
+    """Long-lived E2E session that keeps a UDP socket open for fast polling.
 
-    home_alive = build_alive_packet(
-        sender_end_id=e2e_creds["home_end_id"],
-        sender_group_id=e2e_creds["home_group_id"],
-        end_secret=e2e_creds["home_end_secret"],
-    )
-    dev_alive = build_alive_packet(
-        sender_end_id=e2e_creds["sender_end_id"],
-        sender_group_id=e2e_creds["sender_group_id"],
-        end_secret=e2e_creds["sender_end_secret"],
-    )
-    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
-    power_pkt = build_subscription_packet(
-        e2e_creds, 0x30, session_nonce, payload=bytes([0x01]),
-    )
+    The default helpers (``read_power_flow``, ``read_overrides``, etc.) open a
+    new UDP socket and run the full alive→heartbeat handshake for every call.
+    For real-time monitoring this is too expensive.
 
-    host, port = _resolve_host(e2e_creds["host"])
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.settimeout(timeout)
-    addr = (host, port)
+    ``PersistentE2ESession`` performs the handshake once, then keeps the
+    session alive with periodic keepalives. Subsequent action calls reuse the
+    same socket and complete in a single request/response round trip.
 
-    def _send(pkt: bytes, label: str) -> bytes | None:
-        sock.sendto(pkt, addr)
+    The session expires on the relay server after a few minutes without
+    keepalive (status 21204). Call :meth:`keepalive` periodically (every
+    ~15 seconds) from a background thread or asyncio task to prevent this.
+    The session automatically re-runs the handshake on :meth:`read_power_flow`
+    if a 21204 error is detected.
+
+    Typical usage (synchronous)::
+
+        from emaldo import EmaldoClient
+        from emaldo.e2e import PersistentE2ESession
+
+        client = EmaldoClient()
+        client.login(email, password)
+        creds = client.e2e_login(home_id, device_id, model)
+
+        session = PersistentE2ESession(creds)
+        session.connect()
         try:
-            resp, _ = sock.recvfrom(4096)
-            if log:
-                log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
-            return resp
-        except socket.timeout:
-            if log:
-                log(f"{label}: sent {len(pkt)}B → no response")
-            return None
+            data = session.read_power_flow()  # fast — reuses socket
+            print(data)
+        finally:
+            session.close()
 
-    try:
-        _send(home_alive, "Alive(home)")
-        _send(dev_alive, "Alive(device)")
-        _send(heartbeat, "Heartbeat")
+    Typical usage (with background keepalive)::
+
+        import threading
+
+        session = PersistentE2ESession(creds)
+        session.connect()
+
+        def _keepalive_loop():
+            while not session.closed:
+                time.sleep(15)
+                session.keepalive()
+
+        threading.Thread(target=_keepalive_loop, daemon=True).start()
+    """
+
+    #: Keepalive interval in seconds. The relay server times out idle sessions
+    #: after ~3 minutes; 15 seconds provides a generous safety margin.
+    DEFAULT_KEEPALIVE_INTERVAL = 15
+
+    #: Status code returned when the relay has dropped the session.
+    SESSION_EXPIRED_STATUS = 21204
+
+    def __init__(
+        self,
+        e2e_creds: dict,
+        *,
+        timeout: float = 5.0,
+        log: Callable[..., None] | None = None,
+    ) -> None:
+        self._creds = e2e_creds
+        self._timeout = timeout
+        self._log = log
+        self._sock: socket.socket | None = None
+        self._addr: tuple[str, int] | None = None
+        self._session_nonce: str | None = None
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        """True once :meth:`close` has been called."""
+        return self._closed
+
+    @property
+    def connected(self) -> bool:
+        """True when the session has an open socket and valid handshake."""
+        return self._sock is not None and not self._closed
+
+    def connect(self) -> None:
+        """Open the UDP socket and run the alive+heartbeat handshake."""
+        if self._sock is not None:
+            return
+
+        host, port = _resolve_host(self._creds["host"])
+        self._addr = (host, port)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(self._timeout)
+
+        self._session_nonce = generate_nonce()
+        self._do_handshake()
+
+    def _do_handshake(self) -> None:
+        """Run alive(home) + alive(device) + heartbeat."""
+        home_alive = build_alive_packet(
+            sender_end_id=self._creds["home_end_id"],
+            sender_group_id=self._creds["home_group_id"],
+            end_secret=self._creds["home_end_secret"],
+        )
+        dev_alive = build_alive_packet(
+            sender_end_id=self._creds["sender_end_id"],
+            sender_group_id=self._creds["sender_group_id"],
+            end_secret=self._creds["sender_end_secret"],
+        )
+        heartbeat = build_heartbeat_packet(self._creds, self._session_nonce)
+
+        self._send_raw(home_alive, "Alive(home)")
+        self._send_raw(dev_alive, "Alive(device)")
+        self._send_raw(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
-        resp = _send(power_pkt, "PowerFlow(0x30)")
-        if not resp:
+    def keepalive(self) -> bool:
+        """Send a fresh alive+heartbeat to keep the session alive.
+
+        Returns:
+            True on success, False if the session has been dropped or the
+            socket is closed.
+        """
+        if self._sock is None or self._closed:
+            return False
+
+        try:
+            dev_alive = build_alive_packet(
+                sender_end_id=self._creds["sender_end_id"],
+                sender_group_id=self._creds["sender_group_id"],
+                end_secret=self._creds["sender_end_secret"],
+            )
+            heartbeat = build_heartbeat_packet(self._creds, self._session_nonce)
+            self._send_raw(dev_alive, "Keepalive(alive)")
+            self._send_raw(heartbeat, "Keepalive(heartbeat)")
+            return True
+        except Exception as err:  # noqa: BLE001 - best-effort keepalive
+            if self._log:
+                self._log(f"Keepalive failed: {err}")
+            return False
+
+    def read_power_flow(self) -> dict | None:
+        """Read realtime power flow (0x30) over the existing session.
+
+        Automatically re-runs the handshake if the relay has dropped the
+        session (status 21204).
+        """
+        if self._sock is None or self._closed:
+            raise EmaldoE2EError("Session is not connected")
+
+        for attempt in range(2):
+            power_pkt = build_subscription_packet(
+                self._creds, 0x30, self._session_nonce, payload=bytes([0x01]),
+            )
+            resp = self._send_raw(power_pkt, "PowerFlow(0x30)")
+            if resp is None:
+                # Timeout — maybe session expired. Try reconnect once.
+                if attempt == 0:
+                    self._reconnect()
+                    continue
+                return None
+
+            # Check for session-expired status
+            if self._is_session_expired(resp):
+                if self._log:
+                    self._log("Session expired, reconnecting")
+                if attempt == 0:
+                    self._reconnect()
+                    continue
+                return None
+
+            decrypted = decrypt_response(
+                resp, self._creds["chat_secret"],
+                payload_validator=_is_power_flow_payload,
+            )
+            result = parse_power_flow(decrypted)
+            if result is not None:
+                return result
+
+            # Drain a few more in case we got an echo/ACK first
+            for _ in range(5):
+                try:
+                    more_resp, _ = self._sock.recvfrom(4096)
+                    decrypted = decrypt_response(
+                        more_resp, self._creds["chat_secret"],
+                        payload_validator=_is_power_flow_payload,
+                    )
+                    result = parse_power_flow(decrypted)
+                    if result is not None:
+                        return result
+                except socket.timeout:
+                    break
+
             return None
 
-        decrypted = decrypt_response(
-            resp, e2e_creds["chat_secret"],
-            payload_validator=_is_power_flow_payload,
-        )
-        result = parse_power_flow(decrypted)
-        if result is not None:
-            return result
-
-        # First response may be an echo/ACK; try a few more
-        for _ in range(5):
-            try:
-                resp, _ = sock.recvfrom(4096)
-                decrypted = decrypt_response(
-                    resp, e2e_creds["chat_secret"],
-                    payload_validator=_is_power_flow_payload,
-                )
-                result = parse_power_flow(decrypted)
-                if result is not None:
-                    return result
-            except socket.timeout:
-                break
-
         return None
-    finally:
-        sock.close()
+
+    def close(self) -> None:
+        """Close the socket and mark the session closed."""
+        self._closed = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._sock = None
+
+    def _send_raw(self, pkt: bytes, label: str) -> bytes | None:
+        """Send a packet and read one response (no reconnect logic)."""
+        if self._sock is None or self._addr is None:
+            return None
+        self._sock.sendto(pkt, self._addr)
+        try:
+            resp, _ = self._sock.recvfrom(4096)
+            if self._log:
+                self._log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if self._log:
+                self._log(f"{label}: sent {len(pkt)}B → no response")
+            return None
+
+    def _reconnect(self) -> None:
+        """Close and re-open the session (used on 21204 or timeout)."""
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._sock = None
+        host, port = _resolve_host(self._creds["host"])
+        self._addr = (host, port)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(self._timeout)
+        self._session_nonce = generate_nonce()
+        self._do_handshake()
+
+    @classmethod
+    def _is_session_expired(cls, resp: bytes) -> bool:
+        """Check if a response contains the 21204 (session expired) status."""
+        if resp is None or len(resp) < 2:
+            return False
+        # Parse the OPTION_STATUS (0xC0) field if present.
+        pos = 1
+        options = 0
+        if resp[0] & 1:
+            while pos + 1 < len(resp):
+                length_byte = resp[pos]
+                vl = length_byte & 0x7F
+                has_more = bool(length_byte & 0x80)
+                if pos + 2 + vl > len(resp):
+                    break
+                opt_type = resp[pos + 1]
+                if opt_type == 0xC0 and vl == 2:
+                    status = int.from_bytes(resp[pos + 2:pos + 4], "big")
+                    return status == cls.SESSION_EXPIRED_STATUS
+                pos += 2 + vl
+                options += 1
+                if not has_more:
+                    break
+        return False

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -89,41 +89,36 @@ def _battery_discharged_today(data: dict[str, Any]) -> float | None:
 
 def _battery_power(data: dict[str, Any]) -> float | None:
     """Battery power in W (positive = charging, negative = discharging)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("battery_w")
+    if isinstance(data, dict):
+        return data.get("battery_w")
     return None
 
 
 def _grid_power(data: dict[str, Any]) -> float | None:
     """Grid power in W (positive = importing, negative = exporting)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("grid_w")
+    if isinstance(data, dict):
+        return data.get("grid_w")
     return None
 
 
 def _dual_power(data: dict[str, Any]) -> float | None:
     """Building consumption in W (negative = consuming)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("dual_power_w")
+    if isinstance(data, dict):
+        return data.get("dual_power_w")
     return None
 
 
 def _solar_power(data: dict[str, Any]) -> float | None:
     """Solar PV power in W (Power Core only)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("solar_w")
+    if isinstance(data, dict):
+        return data.get("solar_w")
     return None
 
 
 def _car_charge_power(data: dict[str, Any]) -> float | None:
     """EV charger power in W (Power Core only)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("ev_w")
+    if isinstance(data, dict):
+        return data.get("ev_w")
     return None
 
 
@@ -137,7 +132,8 @@ class EmaldoSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[dict[str, Any]], float | None]
 
 
-SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
+# Sensors that read from the slow REST coordinator (battery + energy totals)
+REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_soc",
         name="Battery SoC",
@@ -162,6 +158,10 @@ SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         value_fn=_battery_discharged_today,
     ),
+)
+
+# Sensors that read from the fast E2E realtime coordinator (power flow)
+REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_power",
         name="Battery power",
@@ -188,8 +188,8 @@ SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     ),
 )
 
-# Sensors only available on Power Core models (PC1-BAK15-HS10, PC3)
-POWER_CORE_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
+# Power Core only (PC1-BAK15-HS10, PC3) — also from realtime coordinator
+POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="solar_power",
         name="Solar power",
@@ -217,19 +217,26 @@ async def async_setup_entry(
     """Set up Emaldo sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator: EmaldoCoordinator = data["power"]
+    realtime_coordinator = data["realtime"]
     schedule_coordinator: EmaldoScheduleCoordinator = data["schedule"]
 
     entities: list[SensorEntity] = [
         EmaldoSensor(coordinator, description)
-        for description in SENSOR_DESCRIPTIONS
+        for description in REST_SENSOR_DESCRIPTIONS
     ]
 
-    # Power Core models have built-in solar PV and EV charger
+    # Real-time power sensors come from the E2E coordinator
+    entities.extend(
+        EmaldoSensor(realtime_coordinator, description)
+        for description in REALTIME_SENSOR_DESCRIPTIONS
+    )
+
+    # Power Core models have built-in solar PV and EV charger — also realtime
     model = coordinator.device_model or ""
     if model.startswith("PC"):
         entities.extend(
-            EmaldoSensor(coordinator, desc)
-            for desc in POWER_CORE_SENSOR_DESCRIPTIONS
+            EmaldoSensor(realtime_coordinator, desc)
+            for desc in POWER_CORE_REALTIME_DESCRIPTIONS
         )
 
     entities.append(EmaldoPlanSourceSensor(schedule_coordinator))

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -87,6 +87,59 @@ def _battery_discharged_today(data: dict[str, Any]) -> float | None:
     return round(total * 5 / 60 / 1000, 2)
 
 
+def _sum_series(series: dict | None, column: int, interval_min: int = 5) -> float | None:
+    """Sum a column from a 5-minute-interval power series and return kWh."""
+    if not isinstance(series, dict):
+        return None
+    entries = series.get("data", [])
+    if not entries:
+        return None
+    total = sum(e[column] for e in entries if len(e) > column)
+    return round(total * interval_min / 60 / 1000, 3)
+
+
+def _solar_energy_today(data: dict[str, Any]) -> float | None:
+    """Total solar energy produced today (sum of all MPPT strings)."""
+    solar_resp = data.get("solar")
+    if not isinstance(solar_resp, dict):
+        return None
+    series = solar_resp.get("mppt") if "mppt" in solar_resp else solar_resp
+    if not isinstance(series, dict):
+        return None
+    entries = series.get("data", [])
+    if not entries:
+        return None
+    # Sum all columns except the first (time offset)
+    ncols = len(entries[0]) - 1 if entries else 0
+    total = sum(
+        sum(e[i + 1] for i in range(ncols) if len(e) > i + 1)
+        for e in entries
+    )
+    return round(total * 5 / 60 / 1000, 3)
+
+
+def _grid_import_today(data: dict[str, Any]) -> float | None:
+    """Total grid import energy today.
+
+    The grid stats endpoint with ``get_real=True`` returns 13 columns per row:
+    ``[time_offset, import_W, ?, export_W, ?, phantom_W, 0, ...]``.
+    """
+    grid_resp = data.get("power", {}).get("grid")
+    return _sum_series(grid_resp, column=1)
+
+
+def _grid_export_today(data: dict[str, Any]) -> float | None:
+    """Total grid export energy today (col[3] of grid stats with get_real)."""
+    grid_resp = data.get("power", {}).get("grid")
+    return _sum_series(grid_resp, column=3)
+
+
+def _load_energy_today(data: dict[str, Any]) -> float | None:
+    """Total property load energy today (col[2] of usage stats)."""
+    usage_resp = data.get("power", {}).get("usage")
+    return _sum_series(usage_resp, column=2)
+
+
 def _battery_power(data: dict[str, Any]) -> float | None:
     """Battery power in W (positive = charging, negative = discharging)."""
     if isinstance(data, dict):
@@ -158,6 +211,42 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         value_fn=_battery_discharged_today,
     ),
+    EmaldoSensorEntityDescription(
+        key="solar_energy_today",
+        name="Solar energy today",
+        icon="mdi:solar-power",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_solar_energy_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="grid_import_today",
+        name="Grid import today",
+        icon="mdi:transmission-tower-import",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_grid_import_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="grid_export_today",
+        name="Grid export today",
+        icon="mdi:transmission-tower-export",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_grid_export_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="load_energy_today",
+        name="Load energy today",
+        icon="mdi:home-lightning-bolt",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_load_energy_today,
+    ),
 )
 
 # Sensors that read from the fast E2E realtime coordinator (power flow)
@@ -165,6 +254,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_power",
         name="Battery power",
+        icon="mdi:battery-charging",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -173,6 +263,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="grid_power",
         name="Grid power",
+        icon="mdi:transmission-tower",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -181,6 +272,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="dual_power",
         name="Consumption",
+        icon="mdi:home-lightning-bolt",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -193,6 +285,7 @@ POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="solar_power",
         name="Solar power",
+        icon="mdi:solar-power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -201,6 +294,7 @@ POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="car_charge_power",
         name="Car charge power",
+        icon="mdi:car-electric",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Summary

Adds four new energy (kWh) sensors that are missing for Home Assistant's Energy Dashboard configuration:

| Sensor | Source |
|--------|--------|
| **Solar energy today** | `client.get_solar()` — sum of all MPPT strings |
| **Grid import today** | `client.get_power()` → grid → col[1] |
| **Grid export today** | `client.get_power()` → grid → col[3] |
| **Load energy today** | `client.get_power()` → usage → col[2] |

All use `state_class=total` with `device_class=energy` so they can be selected directly in the Energy Dashboard.

## Why

The existing integration only exposes `battery_charged_today` and `battery_discharged_today`. The HA Energy Dashboard needs solar, grid import, grid export, and household consumption sensors to render the energy flow visualisation — without these, users must fall back to `sensor.integration` Riemann sum helpers on the power sensors (less accurate, more fragile).

## Also in this PR

- **MDI icons** on all power and energy sensors (`mdi:solar-power`, `mdi:battery-charging`, `mdi:transmission-tower`/`-import`/`-export`, `mdi:home-lightning-bolt`, `mdi:car-electric`)
- `coordinator.py` now fetches `client.get_solar()` on best-effort basis — won't fail the update if the device has no solar or the call errors out
- New `_sum_series()` helper in `sensor.py` for integrating 5-minute power series into daily kWh totals

## Verification

Values cross-referenced against:
1. The Emaldo mobile app's daily statistics screen
2. An external 3-phase grid meter (Talo3P sensors in HA)

| Source | Grid import today | Grid export today |
|--------|-------------------|-------------------|
| Emaldo app (mobile) | 42 kWh | 4.6 kWh |
| External meter (Talo3P) | 43.05 kWh | 5.80 kWh |
| This integration (col[1]/col[3]) | 41.24 kWh | 4.29 kWh |

Small differences are expected because the Emaldo inverter CT and the grid meter measure at slightly different points.

## Note on column indexes

The `/bmt/stats/grid/day/` endpoint returns **13 columns** when called with `get_real=True` (as `client.get_power()` does):

\`\`\`
[time_offset, import, ?, export, ?, phantom, 0, 0, 0, 0, 0, 0, 0]
```

- col[1] = grid import (W)
- col[3] = grid export (W)
- col[5] = constant ~300W offset (likely phantom/CT bias — verified by constant 300W rows)

Without `get_real`, the endpoint returns a different structure. If you run into compatibility issues with other device models, we may need to probe the schema at runtime.