### PR TITLE
Add realtime E2E, Energy Dashboard sensors, EV control, and bug fixes

### DIFF
--- a/custom_components/emaldo/__init__.py
+++ b/custom_components/emaldo/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .coordinator import EmaldoCoordinator
+from .coordinator import EmaldoCoordinator, EmaldoRealtimeCoordinator
 from .schedule_coordinator import EmaldoScheduleCoordinator
 from .services import async_register_services, async_unregister_services
 
@@ -19,12 +19,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     power_coordinator = EmaldoCoordinator(hass, entry)
     await power_coordinator.async_config_entry_first_refresh()
 
+    realtime_coordinator = EmaldoRealtimeCoordinator(hass, entry, power_coordinator)
+    # Best-effort first refresh — if E2E fails, keep the integration working
+    # with the slower REST power data.
+    try:
+        await realtime_coordinator.async_config_entry_first_refresh()
+    except Exception:  # noqa: BLE001
+        pass
+
     schedule_coordinator = EmaldoScheduleCoordinator(hass, entry)
     await schedule_coordinator.async_config_entry_first_refresh()
     schedule_coordinator.async_setup_listeners()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "power": power_coordinator,
+        "realtime": realtime_coordinator,
         "schedule": schedule_coordinator,
     }
 
@@ -52,6 +61,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data = hass.data[DOMAIN].pop(entry.entry_id)
         data["schedule"].async_shutdown()
+        await data["realtime"].async_shutdown()
         if not hass.data[DOMAIN]:
             async_unregister_services(hass)
     return unload_ok

--- a/custom_components/emaldo/__init__.py
+++ b/custom_components/emaldo/__init__.py
@@ -11,7 +11,11 @@ from .coordinator import EmaldoCoordinator, EmaldoRealtimeCoordinator
 from .schedule_coordinator import EmaldoScheduleCoordinator
 from .services import async_register_services, async_unregister_services
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.SELECT,
+    Platform.NUMBER,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/emaldo/const.py
+++ b/custom_components/emaldo/const.py
@@ -7,7 +7,9 @@ CONF_APP_ID = "app_id"
 CONF_APP_SECRET = "app_secret"
 CONF_APP_VERSION = "app_version"
 
-DEFAULT_SCAN_INTERVAL = 60  # seconds
+DEFAULT_SCAN_INTERVAL = 60  # seconds (REST battery + power)
+REALTIME_SCAN_INTERVAL = 10  # seconds (E2E power flow, persistent session)
+KEEPALIVE_INTERVAL = 15  # seconds (E2E relay session keepalive)
 
 # Schedule polling configuration
 CONF_SCHEDULE_START_HOUR = "schedule_start_hour"

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -172,6 +172,16 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
         self._parent = parent
         self._session: PersistentE2ESession | None = None
         self._keepalive_task: asyncio.Task | None = None
+        self._empty_reads: int = 0
+        # -- Stats for diagnostic sensor --
+        self.stats_total_polls: int = 0
+        self.stats_successful_polls: int = 0
+        self.stats_empty_reads: int = 0
+        self.stats_reconnects: int = 0
+        self.stats_keepalive_failures: int = 0
+        self.stats_last_success: float | None = None
+        self.stats_last_failure: float | None = None
+        self.stats_last_reconnect: float | None = None
 
     # -- Proxy properties so sensors can share one class across coordinators --
 
@@ -230,22 +240,36 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
             self._session = None
         return data
 
+    #: Tolerate this many consecutive empty reads before surfacing unavailable.
+    _MAX_EMPTY_READS = 3
+
     async def _async_update_data(self) -> dict[str, Any] | None:
-        """Fetch realtime power flow via the persistent E2E session."""
+        """Fetch realtime power flow via the persistent E2E session.
+
+        Single empty reads are tolerated (the previous value is kept in
+        ``self.data``). After ``_MAX_EMPTY_READS`` consecutive failures the
+        session is torn down and the coordinator raises UpdateFailed so HA
+        surfaces the issue.
+        """
+        import time as _time
+        self.stats_total_polls += 1
+
         try:
             data = await self.hass.async_add_executor_job(self._read_power_flow)
         except EmaldoAuthError as err:
             # Token expired — force REST re-login and E2E reconnect
             self._parent._client = None  # noqa: SLF001
             await self._close_session()
+            self._empty_reads = 0
+            self.stats_last_failure = _time.time()
+            _LOGGER.warning("E2E auth failed, will re-login on next poll: %s", err)
             raise UpdateFailed(f"E2E auth failed: {err}") from err
         except Exception as err:
             await self._close_session()
+            self._empty_reads = 0
+            self.stats_last_failure = _time.time()
+            _LOGGER.warning("E2E power flow read failed: %s", err)
             raise UpdateFailed(f"E2E power flow read failed: {err}") from err
-
-        if data is None:
-            await self._close_session()
-            raise UpdateFailed("No power flow data returned")
 
         # Ensure keepalive task is running
         if self._keepalive_task is None or self._keepalive_task.done():
@@ -253,6 +277,33 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
                 self._keepalive_loop(), name=f"{DOMAIN}_keepalive"
             )
 
+        if data is None:
+            self._empty_reads += 1
+            self.stats_empty_reads += 1
+            self.stats_last_failure = _time.time()
+            if self._empty_reads >= self._MAX_EMPTY_READS:
+                self.stats_reconnects += 1
+                self.stats_last_reconnect = _time.time()
+                _LOGGER.warning(
+                    "E2E power flow: %d consecutive empty reads, reconnecting "
+                    "(total drops: %d, reconnects: %d since start)",
+                    self._empty_reads,
+                    self.stats_empty_reads,
+                    self.stats_reconnects,
+                )
+                await self._close_session()
+                self._empty_reads = 0
+                raise UpdateFailed("No power flow data returned")
+            # Keep previous data visible to sensors
+            _LOGGER.info(
+                "E2E power flow empty read %d/%d, keeping previous values",
+                self._empty_reads, self._MAX_EMPTY_READS,
+            )
+            return self.data
+
+        self._empty_reads = 0
+        self.stats_successful_polls += 1
+        self.stats_last_success = _time.time()
         return data
 
     async def _close_session(self) -> None:
@@ -266,6 +317,7 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
 
     async def _keepalive_loop(self) -> None:
         """Periodically send alive+heartbeat to keep the relay session alive."""
+        import time as _time
         fail_count = 0
         try:
             while True:
@@ -281,9 +333,15 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
                     fail_count = 0
                 else:
                     fail_count += 1
-                    _LOGGER.debug("Keepalive fail #%d", fail_count)
+                    self.stats_keepalive_failures += 1
+                    _LOGGER.info(
+                        "Keepalive fail #%d (total keepalive failures: %d)",
+                        fail_count, self.stats_keepalive_failures,
+                    )
                     if fail_count >= 2:
-                        _LOGGER.info("Keepalive failed twice, closing session for reconnect")
+                        _LOGGER.warning(
+                            "Keepalive failed twice, closing session for reconnect"
+                        )
                         await self._close_session()
                         return
         except asyncio.CancelledError:

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -1,7 +1,14 @@
-"""DataUpdateCoordinator for Emaldo."""
+"""DataUpdateCoordinators for Emaldo.
+
+Two coordinators:
+* :class:`EmaldoCoordinator` — slow REST + battery details (60s interval)
+* :class:`EmaldoRealtimeCoordinator` — fast E2E power flow via a persistent
+  UDP session (10s interval).
+"""
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -11,7 +18,12 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .emaldo_lib import EmaldoClient, EmaldoAuthError, EmaldoConnectionError
+from .emaldo_lib import (
+    EmaldoClient,
+    EmaldoAuthError,
+    EmaldoConnectionError,
+    PersistentE2ESession,
+)
 from .emaldo_lib.const import set_params
 
 from .const import (
@@ -21,13 +33,15 @@ from .const import (
     CONF_APP_SECRET,
     CONF_APP_VERSION,
     DEFAULT_SCAN_INTERVAL,
+    REALTIME_SCAN_INTERVAL,
+    KEEPALIVE_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator to poll Emaldo API."""
+    """Slow coordinator for REST battery/power data (60s)."""
 
     config_entry: ConfigEntry
 
@@ -85,7 +99,7 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self._client
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from Emaldo API."""
+        """Fetch battery + power data from the REST API."""
         for attempt in range(2):
             try:
                 client = await self.hass.async_add_executor_job(self._ensure_client)
@@ -107,18 +121,160 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as err:
                 raise UpdateFailed(f"Error fetching Emaldo data: {err}") from err
 
-        # E2E power flow (best-effort, don't fail the whole update)
-        power_flow = None
-        try:
-            power_flow = await self.hass.async_add_executor_job(
-                client.get_power_flow,
-                self.home_id, self._device_id, self._model,
-            )
-        except Exception as err:
-            _LOGGER.debug("E2E power flow read failed: %s", err)
-
         return {
             "battery": battery,
             "power": power,
-            "power_flow": power_flow,
         }
+
+
+class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
+    """Fast coordinator for E2E real-time power flow (10s).
+
+    Uses :class:`PersistentE2ESession` to keep a UDP socket open across polls,
+    reducing latency from ~500ms to ~85ms per read. A background task sends
+    keepalive messages every 15 seconds to prevent the relay server from
+    dropping the session.
+    """
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        parent: EmaldoCoordinator,
+    ) -> None:
+        """Initialize the realtime coordinator.
+
+        Args:
+            hass: Home Assistant instance.
+            entry: Config entry.
+            parent: The slow :class:`EmaldoCoordinator` — used to share the
+                authenticated REST client and device discovery.
+        """
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_realtime",
+            update_interval=timedelta(seconds=REALTIME_SCAN_INTERVAL),
+        )
+        self._entry = entry
+        self._parent = parent
+        self._session: PersistentE2ESession | None = None
+        self._keepalive_task: asyncio.Task | None = None
+
+    # -- Proxy properties so sensors can share one class across coordinators --
+
+    @property
+    def home_id(self) -> str:
+        return self._parent.home_id
+
+    @property
+    def device_id(self) -> str | None:
+        return self._parent.device_id
+
+    @property
+    def device_model(self) -> str | None:
+        return self._parent.device_model
+
+    @property
+    def device_name(self) -> str | None:
+        return self._parent.device_name
+
+    async def async_shutdown(self) -> None:
+        """Cancel keepalive and close the UDP session."""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._keepalive_task = None
+        if self._session is not None:
+            await self.hass.async_add_executor_job(self._session.close)
+            self._session = None
+
+    def _ensure_session(self) -> PersistentE2ESession:
+        """Create and connect the persistent E2E session if needed."""
+        if self._session is not None and not self._session.closed:
+            return self._session
+
+        client = self._parent._ensure_client()  # noqa: SLF001 - intended
+        home_id = self._parent.home_id
+        device_id = self._parent._device_id  # noqa: SLF001
+        model = self._parent._model  # noqa: SLF001
+        if device_id is None or model is None:
+            raise UpdateFailed("Device not yet discovered")
+
+        creds = client.e2e_login(home_id, device_id, model)
+        self._session = PersistentE2ESession(creds)
+        self._session.connect()
+        return self._session
+
+    def _read_power_flow(self) -> dict | None:
+        """Synchronous helper that runs in the executor."""
+        session = self._ensure_session()
+        data = session.read_power_flow()
+        if data is None and session.closed:
+            # Session died mid-read — force recreation on next call
+            self._session = None
+        return data
+
+    async def _async_update_data(self) -> dict[str, Any] | None:
+        """Fetch realtime power flow via the persistent E2E session."""
+        try:
+            data = await self.hass.async_add_executor_job(self._read_power_flow)
+        except EmaldoAuthError as err:
+            # Token expired — force REST re-login and E2E reconnect
+            self._parent._client = None  # noqa: SLF001
+            await self._close_session()
+            raise UpdateFailed(f"E2E auth failed: {err}") from err
+        except Exception as err:
+            await self._close_session()
+            raise UpdateFailed(f"E2E power flow read failed: {err}") from err
+
+        if data is None:
+            await self._close_session()
+            raise UpdateFailed("No power flow data returned")
+
+        # Ensure keepalive task is running
+        if self._keepalive_task is None or self._keepalive_task.done():
+            self._keepalive_task = self.hass.async_create_task(
+                self._keepalive_loop(), name=f"{DOMAIN}_keepalive"
+            )
+
+        return data
+
+    async def _close_session(self) -> None:
+        """Close the current session (if any)."""
+        if self._session is not None:
+            try:
+                await self.hass.async_add_executor_job(self._session.close)
+            except Exception:  # noqa: BLE001
+                pass
+            self._session = None
+
+    async def _keepalive_loop(self) -> None:
+        """Periodically send alive+heartbeat to keep the relay session alive."""
+        fail_count = 0
+        try:
+            while True:
+                await asyncio.sleep(KEEPALIVE_INTERVAL)
+                if self._session is None or self._session.closed:
+                    return
+                try:
+                    ok = await self.hass.async_add_executor_job(self._session.keepalive)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug("Keepalive error: %s", err)
+                    ok = False
+                if ok:
+                    fail_count = 0
+                else:
+                    fail_count += 1
+                    _LOGGER.debug("Keepalive fail #%d", fail_count)
+                    if fail_count >= 2:
+                        _LOGGER.info("Keepalive failed twice, closing session for reconnect")
+                        await self._close_session()
+                        return
+        except asyncio.CancelledError:
+            pass

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -121,9 +121,19 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as err:
                 raise UpdateFailed(f"Error fetching Emaldo data: {err}") from err
 
+        # Solar MPPT stats — best-effort, not all devices have solar
+        solar = None
+        try:
+            solar = await self.hass.async_add_executor_job(
+                client.get_solar, self.home_id, self._device_id, self._model
+            )
+        except Exception as err:
+            _LOGGER.debug("Solar stats fetch failed: %s", err)
+
         return {
             "battery": battery,
             "power": power,
+            "solar": solar,
         }
 
 

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -25,6 +25,14 @@ from .emaldo_lib import (
     PersistentE2ESession,
 )
 from .emaldo_lib.const import set_params
+from .emaldo_lib.e2e import (
+    build_subscription_packet,
+    decrypt_response,
+    generate_nonce,
+    _run_session,
+    parse_ev_charging_info,
+    _EV_TYPE_GET_STATE,
+)
 
 from .const import (
     DOMAIN,
@@ -130,10 +138,87 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             _LOGGER.debug("Solar stats fetch failed: %s", err)
 
+        # EV charging mode + schedule — best-effort, only Power Core
+        # hardware (with EV charger) exposes these commands. Errors are
+        # swallowed so a device without EV support doesn't break the
+        # whole coordinator refresh.
+        ev = None
+        try:
+            ev = await self.hass.async_add_executor_job(
+                self._read_ev_state
+            )
+        except Exception as err:
+            _LOGGER.debug("EV state fetch failed: %s", err)
+
         return {
             "battery": battery,
             "power": power,
             "solar": solar,
+            "ev": ev,
+        }
+
+    def _read_ev_state(self) -> dict | None:
+        """Read EV charging mode (wire 0x20) and schedule (wire 0x21).
+
+        Runs synchronously in the executor. Returns a dict with keys
+        ``mode``, ``fixed_kwh``, ``fixed_full_kwh``, ``price_percent``,
+        ``weekdays`` (list of 24 ints), ``weekend`` (list of 24 ints),
+        and ``sync`` (int), or *None* if the device doesn't support EV
+        commands / both reads failed.
+        """
+        client = self._ensure_client()
+        creds = client.e2e_login(self.home_id, self._device_id, self._model)
+
+        # 1) Current mode + fixed values (0x20 → 6 bytes)
+        session_nonce = generate_nonce()
+        mode_pkt = build_subscription_packet(
+            creds, _EV_TYPE_GET_STATE, session_nonce, payload=b"",
+        )
+        mode_results = _run_session(
+            creds, [("Read EV mode", mode_pkt)], timeout=3.0,
+        )
+        _, mode_resp = mode_results[0]
+        mode_info = None
+        if mode_resp is not None:
+            mode_dec = decrypt_response(
+                mode_resp, creds["chat_secret"],
+                payload_validator=lambda p: len(p) == 6,
+            )
+            mode_info = parse_ev_charging_info(mode_dec)
+
+        if mode_info is None:
+            return None
+
+        # 2) Schedule bitmaps (0x21 → 7 bytes)
+        sched_nonce = generate_nonce()
+        sched_pkt = build_subscription_packet(
+            creds, 0x21, sched_nonce, payload=b"",
+        )
+        sched_results = _run_session(
+            creds, [("Read EV schedule", sched_pkt)], timeout=3.0,
+        )
+        _, sched_resp = sched_results[0]
+        weekdays = [0] * 24
+        weekend = [0] * 24
+        sync_flag = 0
+        if sched_resp is not None:
+            sched_dec = decrypt_response(
+                sched_resp, creds["chat_secret"],
+                payload_validator=lambda p: len(p) >= 7,
+            )
+            if sched_dec is not None and len(sched_dec) >= 7:
+                # Bytes 0..2 = weekdays bitmap, 3..5 = weekend, 6 = sync
+                def _unpack(bs: bytes) -> list[int]:
+                    return [(b >> i) & 1 for b in bs for i in range(8)]
+                weekdays = _unpack(sched_dec[0:3])
+                weekend = _unpack(sched_dec[3:6])
+                sync_flag = sched_dec[6]
+
+        return {
+            **mode_info,
+            "weekdays": weekdays,
+            "weekend": weekend,
+            "sync": sync_flag,
         }
 
 

--- a/custom_components/emaldo/emaldo_lib/__init__.py
+++ b/custom_components/emaldo/emaldo_lib/__init__.py
@@ -1,6 +1,14 @@
 """Emaldo battery system API client (bundled for HA integration)."""
 
 from .client import EmaldoClient
+from .e2e import PersistentE2ESession
 from .exceptions import EmaldoError, EmaldoAuthError, EmaldoAPIError, EmaldoConnectionError
 
-__all__ = ["EmaldoClient", "EmaldoError", "EmaldoAuthError", "EmaldoAPIError", "EmaldoConnectionError"]
+__all__ = [
+    "EmaldoClient",
+    "PersistentE2ESession",
+    "EmaldoError",
+    "EmaldoAuthError",
+    "EmaldoAPIError",
+    "EmaldoConnectionError",
+]

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -1435,6 +1435,373 @@ def set_peak_shaving_redundancy(
 
 
 # ---------------------------------------------------------------------------
+# EV charging mode
+# ---------------------------------------------------------------------------
+#
+# The app's EV panel exposes two top-level groups:
+#
+#   Smart Charge
+#     ├── Lowest Price   (mode 1, "lowerUtilityRate")
+#     ├── Solar Only     (mode 2, "solarOnly")
+#     └── Scheduled      (mode 3, "scheduled")
+#   Instant Charge
+#     ├── Until Fully Charged  (mode 4, "instantChargeFull")
+#     └── Fixed X kWh          (mode 5, "instantChargeFixed")
+#
+# Setting a Smart mode and an Instant mode uses DIFFERENT wire commands.
+# Both commands encode the mode enum (1–5), but the payload shapes differ
+# because Smart modes carry an optional 24h×2 weekday/weekend schedule
+# while Instant modes carry only a "fixed" kWh amount.
+#
+# Wire bytes confirmed by packet capture from the Android app:
+#
+#   0x22 = SET_EV_CHARGING_MODE       (Smart modes 1–3, 9-byte payload)
+#   0x31 = SET_EVCHARGINGMODE_INSTANT (Instant modes 4–5, 4-byte payload)
+#   0x29 = SET_EVCHARGINGMODE_INSTANTCHARGE (simple Smart↔Instant toggle, 1 byte)
+#
+# The corresponding Android MSCT OPTION_METHOD shorts (little-endian on
+# the wire, matching the observed `82 f5 XX A0` header sequence):
+#
+#   (short) -24542 = 0xA022 → wire bytes "22 A0" → our msg_type byte 0x22
+#   (short) -24527 = 0xA031 → wire bytes "31 A0" → our msg_type byte 0x31
+#   (short) -24535 = 0xA029 → wire bytes "29 A0" → our msg_type byte 0x29
+#
+# The READ command (``get_current_evchargingmode``, case 62 in j.java,
+# short -24544 = 0xA0E0) is rejected by the cloud relay with "cmd not
+# allowed" — the phone app appears to get its current state from the
+# aggregated panel-load burst or a subscription channel we haven't
+# unwrapped yet. For now, treat all EV setters as fire-and-forget and
+# track state optimistically in the caller.
+
+EV_MODE_LOWEST_PRICE = 1       # Smart: charge during cheapest grid hours
+EV_MODE_SOLAR_ONLY = 2         # Smart: charge only from surplus PV — defined
+                               # in the APK's Mcu.EVChargingMode enum but
+                               # NOT surfaced in the current Android app UI
+                               # (at least on PC1-BAK15-HS10). The wire
+                               # protocol accepts it, but callers should
+                               # treat it as unsupported unless verified
+                               # against their specific hardware.
+EV_MODE_SCHEDULED = 3          # Smart: charge on a weekday/weekend schedule
+EV_MODE_INSTANT_FULL = 4       # Instant: charge flat-out until the car is full
+EV_MODE_INSTANT_FIXED = 5      # Instant: charge exactly ``fixed`` kWh then stop
+
+_EV_TYPE_SET_SMART = 0x22      # SET_EV_CHARGING_MODE (9-byte payload)
+_EV_TYPE_SET_INSTANT = 0x31    # SET_EVCHARGINGMODE_INSTANT (4-byte payload)
+_EV_TYPE_TOGGLE_INSTANTCHARGE = 0x29  # simple Smart↔Instant toggle (1 byte)
+
+
+def _pack_ev_schedule(hours: list[int] | None) -> bytes:
+    """Pack a list of 24 hour flags into 3 bytes (LSB = hour 0).
+
+    Matches the Android app's ``Integer.parseInt(a(list, 0, 7), 2)`` loop:
+    each 8-hour chunk becomes one byte, earliest hour in the low bit.
+    Returns ``b"\\x00\\x00\\x00"`` if *hours* is *None* or < 24 entries.
+    """
+    if hours is None or len(hours) < 24:
+        return b"\x00\x00\x00"
+    out = bytearray(3)
+    for i in range(24):
+        if hours[i]:
+            out[i // 8] |= 1 << (i % 8)
+    return bytes(out)
+
+
+def set_ev_charging_mode_smart(
+    e2e_creds: dict,
+    mode: int,
+    *,
+    weekdays: list[int] | None = None,
+    weekend: list[int] | None = None,
+    sync: bool = False,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Set a Smart-Charge sub-mode (Lowest Price / Solar Only / Scheduled).
+
+    Wire command 0x22 (SET_EV_CHARGING_MODE). Payload is 9 bytes:
+
+        byte 0    = mode - 1                    (0 = Lowest Price, 1 = Solar
+                                                  Only, 2 = Scheduled)
+        byte 1    = 1 if no schedule, 0 if the caller supplied hour bitmaps
+        byte 2..4 = weekday 24-hour bitmap (3 bytes, LSB = hour 0)
+        byte 5..7 = weekend 24-hour bitmap (3 bytes)
+        byte 8    = sync flag (1 = sync to other devices in the home)
+
+    Args:
+        mode: One of :data:`EV_MODE_LOWEST_PRICE`, :data:`EV_MODE_SOLAR_ONLY`,
+            :data:`EV_MODE_SCHEDULED`.
+        weekdays: Optional 24-element list of 0/1 flags (1 = charge allowed
+            in that hour). Only meaningful for ``EV_MODE_SCHEDULED``.
+        weekend: Same as *weekdays* but for Sat/Sun.
+        sync: Mirror the app's "Sync" toggle.
+
+    Returns *True* if the relay acknowledged the write.
+    """
+    if mode not in (EV_MODE_LOWEST_PRICE, EV_MODE_SOLAR_ONLY, EV_MODE_SCHEDULED):
+        raise ValueError(
+            f"mode {mode} is not a Smart sub-mode; use set_ev_charging_mode_instant"
+        )
+
+    has_schedule = (
+        weekdays is not None and len(weekdays) >= 24
+        and weekend is not None and len(weekend) >= 24
+    )
+    payload = bytes([mode - 1, 0 if has_schedule else 1])
+    payload += _pack_ev_schedule(weekdays if has_schedule else None)
+    payload += _pack_ev_schedule(weekend if has_schedule else None)
+    payload += bytes([1 if sync else 0])
+
+    session_nonce = generate_nonce()
+    pkt = build_subscription_packet(
+        e2e_creds, _EV_TYPE_SET_SMART, session_nonce, payload=payload,
+    )
+    results = _run_session(
+        e2e_creds, [("Set EV smart mode", pkt)],
+        timeout=timeout, log=log,
+    )
+    _, resp = results[0]
+    return resp is not None
+
+
+def set_ev_charging_mode_instant(
+    e2e_creds: dict,
+    mode: int,
+    *,
+    fixed_kwh: int = 0,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Set an Instant-Charge sub-mode (Until Full / Fixed kWh).
+
+    Wire command 0x31 (SET_EVCHARGINGMODE_INSTANT). Payload is 4 bytes:
+
+        byte 0    = mode - 1         (3 = Until Full, 4 = Fixed)
+        byte 1    = 0 if mode == 5, else 1
+                    (derived in the Android app as ``i2 == 5 ? 0 : 1``;
+                     probably a "consume fixed value" flag)
+        byte 2..3 = fixed kWh amount as little-endian u16
+                    (0 when mode == 4; value from slider when mode == 5)
+
+    Args:
+        mode: :data:`EV_MODE_INSTANT_FULL` or :data:`EV_MODE_INSTANT_FIXED`.
+        fixed_kwh: Charge amount in kWh. Required when *mode* is
+            ``EV_MODE_INSTANT_FIXED``; ignored for ``EV_MODE_INSTANT_FULL``.
+
+    Returns *True* if the relay acknowledged the write.
+    """
+    if mode not in (EV_MODE_INSTANT_FULL, EV_MODE_INSTANT_FIXED):
+        raise ValueError(
+            f"mode {mode} is not an Instant sub-mode; use set_ev_charging_mode_smart"
+        )
+    if mode == EV_MODE_INSTANT_FULL:
+        fixed_kwh = 0  # field ignored by the device in Full mode
+
+    payload = bytes([
+        mode - 1,
+        0 if mode == EV_MODE_INSTANT_FIXED else 1,
+        fixed_kwh & 0xFF,
+        (fixed_kwh >> 8) & 0xFF,
+    ])
+
+    session_nonce = generate_nonce()
+    pkt = build_subscription_packet(
+        e2e_creds, _EV_TYPE_SET_INSTANT, session_nonce, payload=payload,
+    )
+    results = _run_session(
+        e2e_creds, [("Set EV instant mode", pkt)],
+        timeout=timeout, log=log,
+    )
+    _, resp = results[0]
+    return resp is not None
+
+
+def toggle_ev_instantcharge(
+    e2e_creds: dict,
+    instant_on: bool,
+    *,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Flip the simple Smart↔Instant switch on the EV panel.
+
+    Wire command 0x29 (SET_EVCHARGINGMODE_INSTANTCHARGE). Payload is 1 byte:
+    ``0x01`` enables Instant, ``0x00`` returns to the previously selected
+    Smart sub-mode. This is the command the phone app fires when the user
+    taps the single "Instant Charge" toggle switch (as opposed to drilling
+    into the mode selector and picking a specific variant).
+
+    Returns *True* if the relay acknowledged the write.
+    """
+    payload = bytes([1 if instant_on else 0])
+    session_nonce = generate_nonce()
+    pkt = build_subscription_packet(
+        e2e_creds, _EV_TYPE_TOGGLE_INSTANTCHARGE, session_nonce, payload=payload,
+    )
+    results = _run_session(
+        e2e_creds, [("Toggle EV instant charge", pkt)],
+        timeout=timeout, log=log,
+    )
+    _, resp = results[0]
+    return resp is not None
+
+
+# Wire bytes observed in the panel-load burst when the Android app opens
+# the EV screen. The app fires all of these in parallel and builds the
+# screen from whichever response carries each field it needs.
+#
+# The dedicated ``get_current_evchargingmode`` (wire 0xE0 = short -24544)
+# is rejected by the cloud relay with "cmd not allowed". Instead the EV
+# mode is returned as a *subset* of the panel-load burst — specifically
+# wire byte ``0x20`` returns the 6-byte payload documented in
+# ``module_bmt/zd/m0.java``: ``[mode-1, fixed_lo, fixed_hi,
+# fixedFull_lo, fixedFull_hi, pricePercent]``.
+#
+# Capture source: logs/ev_mode2.pcap (see history 2026-04-11).
+_EV_TYPE_GET_STATE = 0x20  # returns the 6-byte EV charging mode payload
+
+_EV_PANEL_LOAD_BYTES: tuple[int, ...] = (
+    # Data-bearing commands (observed 211B responses):
+    0x02, 0x04, 0x05, 0x30, 0x33,
+    # Empty-ACK and small-data commands (observed 195B responses):
+    0x07, 0x11, 0x16, 0x17, 0x18, 0x20, 0x25, 0x27, 0x43, 0x45,
+    0x50, 0x5D, 0x81,
+)
+
+
+def parse_ev_charging_info(payload: bytes | None) -> dict | None:
+    """Parse a 6-byte EV charging mode response payload.
+
+    Decoded from ``module_bmt/zd/m0.java``'s ``onAckEvent`` handler for
+    ``GET_CURRENT_EV_CHARGING_MODE``:
+
+        byte 0    = mode - 1                           (enum 1–5)
+        byte 1..2 = fixed       (little-endian u16)    (kWh slider value)
+        byte 3..4 = fixedFull   (little-endian u16)    (kWh slider max)
+        byte 5    = pricePercent                       (semantics unknown)
+
+    Args:
+        payload: Decrypted 6-byte payload, or *None*.
+
+    Returns:
+        Parsed dict with keys ``mode``, ``fixed_kwh``, ``fixed_full_kwh``,
+        ``price_percent``, or *None* if *payload* is None / too short.
+    """
+    if payload is None or len(payload) < 6:
+        return None
+    return {
+        "mode": payload[0] + 1,                          # 1–5
+        "fixed_kwh": payload[1] | (payload[2] << 8),     # LE u16
+        "fixed_full_kwh": payload[3] | (payload[4] << 8),
+        "price_percent": payload[5],
+    }
+
+
+def read_ev_charging_mode(
+    e2e_creds: dict,
+    *,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read the current EV charging mode and fixed-charge slider state.
+
+    Sends wire byte :data:`_EV_TYPE_GET_STATE` (0x20), which returns a
+    6-byte payload the Android app uses to render the EV page. The
+    dedicated ``get_current_evchargingmode`` command (wire 0xE0) is
+    blocked by the cloud relay; 0x20 is the only byte in the panel-load
+    burst that returns a matching 6-byte struct, so we use it as the
+    de-facto read command.
+
+    Returns:
+        Dict from :func:`parse_ev_charging_info`, or *None* on failure.
+    """
+    session_nonce = generate_nonce()
+    pkt = build_subscription_packet(
+        e2e_creds, _EV_TYPE_GET_STATE, session_nonce, payload=b"",
+    )
+    results = _run_session(
+        e2e_creds, [("Read EV charging mode", pkt)],
+        timeout=timeout, log=log,
+    )
+    _, resp = results[0]
+    if resp is None:
+        return None
+    decrypted = decrypt_response(
+        resp, e2e_creds["chat_secret"],
+        # Permissive validator: any 6-byte payload is acceptable here
+        # because the response has no distinctive 2-byte header.
+        payload_validator=lambda p: len(p) == 6,
+    )
+    return parse_ev_charging_info(decrypted)
+
+
+def load_ev_page_data(
+    e2e_creds: dict,
+    *,
+    bytes_to_send: tuple[int, ...] | None = None,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> dict[int, bytes]:
+    """Replay the EV panel load burst and collect decrypted responses.
+
+    The Android app does not use a dedicated ``get_current_evchargingmode``
+    command over the cloud relay — that call is rejected with
+    ``"cmd not allowed"``. Instead the app opens the EV screen by firing
+    ~16 different wire bytes in parallel and composes the UI from the
+    aggregate of responses. This helper replays that burst and returns
+    every response we could decrypt.
+
+    Use it as a discovery tool: inspect the returned dict to figure out
+    which wire byte returns a 6-byte payload shaped like the known EV
+    mode response (``[mode-1, fixed_lo, fixed_hi, fixedFull_lo,
+    fixedFull_hi, pricePercent]``, documented in ``module_bmt/zd/m0.java``).
+
+    Args:
+        e2e_creds: Credentials from :func:`EmaldoClient.e2e_login`.
+        bytes_to_send: Optional override of the byte set. Defaults to
+            :data:`_EV_PANEL_LOAD_BYTES` (observed from packet capture).
+        timeout: Per-packet receive timeout.
+        log: Optional logging callback.
+
+    Returns:
+        Dict mapping each wire byte to its decrypted response payload
+        (or ``None`` if the send failed / the response couldn't be
+        decrypted).
+    """
+    probe_bytes = bytes_to_send or _EV_PANEL_LOAD_BYTES
+
+    # Build one packet per byte, each with its own nonce so the device
+    # side doesn't treat them as duplicates of one another.
+    packets: list[tuple[str, bytes]] = []
+    nonces: list[str] = []
+    for b in probe_bytes:
+        nonce = generate_nonce()
+        nonces.append(nonce)
+        # Empty payload: safe for reads, ignored by writes that expect
+        # structured input (they'll just error rather than mutate state).
+        pkt = build_subscription_packet(
+            e2e_creds, b, nonce, payload=b"",
+        )
+        packets.append((f"PanelLoad(0x{b:02x})", pkt))
+
+    results = _run_session(e2e_creds, packets, timeout=timeout, log=log)
+
+    out: dict[int, bytes] = {}
+    for (b, _), (_, resp) in zip(zip(probe_bytes, nonces), results):
+        if resp is None:
+            continue
+        # Try our session's chat_secret first; responses without a
+        # recognized payload shape will come back as ``None`` from
+        # ``decrypt_response``, but we still keep the raw response for
+        # callers that want to inspect plaintext error strings.
+        decrypted = decrypt_response(resp, e2e_creds["chat_secret"])
+        if decrypted is not None:
+            out[b] = decrypted
+        else:
+            out[b] = resp  # raw — caller can sniff for "cmd not allowed"
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Persistent E2E Session (for real-time polling)
 # ---------------------------------------------------------------------------
 

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -1,6 +1,7 @@
 """E2E (UDP) protocol for direct device communication.
 
-Used for reading and writing charge/discharge override schedules.
+Used for reading and writing charge/discharge override schedules
+and for retrieving realtime power flow data directly from the device.
 The protocol uses AES-256-CBC encryption over UDP.
 """
 
@@ -466,14 +467,18 @@ def parse_battery_data(payload: bytes) -> dict | None:
 def _is_power_flow_payload(payload: bytes) -> bool:
     """Check if decrypted payload looks like a power flow response.
 
-    Power flow responses are 16-24 bytes of signed-short watt values.
+    Power flow responses are 16–24 bytes of signed-short watt values.
+    Heuristic: correct length range, reasonable watt values, and
+    boolean flags at bytes 16–17 must be 0 or 1.
     """
     if len(payload) < 16 or len(payload) > 24:
         return False
+    # First two shorts should be reasonable watt values
     battery_w = struct.unpack_from("<h", payload, 0)[0]
     solar_w = struct.unpack_from("<h", payload, 2)[0]
     if abs(battery_w) >= 30000 or abs(solar_w) >= 30000:
         return False
+    # Bytes 16–17 are boolean flags (gridValid, bsensorValid)
     if len(payload) >= 18:
         if payload[16] not in (0, 1) or payload[17] not in (0, 1):
             return False
@@ -483,7 +488,37 @@ def _is_power_flow_payload(payload: bytes) -> bool:
 def parse_power_flow(payload: bytes) -> dict | None:
     """Parse a type 0x30 power-flow response payload.
 
-    Returns a dict with battery_w, solar_w, grid_w, dual_power_w, etc.
+    This is the ``GET_GLOBAL_CURRENT_FLOW_INFO`` command response.
+    The app screen calls it "Realtime Power".
+
+    Payload layout (16–22 bytes, little-endian):
+
+    ======  ====  ======================  ================================
+    Offset  Size  Field                   Description
+    ======  ====  ======================  ================================
+    0-1     2     battery_w               signed short – battery power
+                                          (hectowatts, ×100 = W).
+                                          positive = charging,
+                                          negative = discharging
+    2-3     2     solar_w                 signed short – solar/PV power
+    4-5     2     grid_w                  signed short – grid power
+                                          positive = importing,
+                                          negative = exporting
+    6-7     2     addition_load_w         signed short – additional load
+    8-9     2     other_load_w            signed short – other load
+    10-11   2     ev_w                    signed short – EV charger
+    12-13   2     ip2_w                   unsigned short – input port 2
+    14-15   2     op2_w                   unsigned short – output port 2
+    16      1     grid_valid              bool – grid CT sensor present
+    17      1     bsensor_valid           bool – battery sensor present
+    18      1     solar_efficiency        enum – solar efficiency type
+    19      1     thirdparty_pv_on        bool – 3rd-party PV enabled
+    20-21   2     dual_power_w            signed short – household +
+                                          solar combined (W)
+    ======  ====  ======================  ================================
+
+    Returns:
+        Dict with decoded power flow values, or *None* if invalid.
     """
     if payload is None or len(payload) < 16:
         return None
@@ -499,10 +534,12 @@ def parse_power_flow(payload: bytes) -> dict | None:
     ip2_w = struct.unpack_from("<H", payload, 12)[0] * _scale
     op2_w = struct.unpack_from("<H", payload, 14)[0] * _scale
 
+    # Extended fields (bytes 16-21) may be absent in older firmware
     length = len(payload)
     max_len = max(length, 22)
     buf = bytearray(max_len)
     buf[:length] = payload
+    # Pad missing bytes with defaults (match Java logic)
     for i in range(length, max_len):
         buf[i] = 1 if i in (16, 17) else 0
 
@@ -803,6 +840,124 @@ def read_battery_info(
                     break
 
         return batteries
+    finally:
+        sock.close()
+
+
+def _log_power_flow_raw(payload: bytes, log: Callable[..., None]) -> None:
+    """Dump raw power flow payload for debugging."""
+    log(f"Raw payload ({len(payload)}B): {payload.hex()}")
+    if len(payload) >= 2:
+        log(f"  [0:2]   batteryWat      = {struct.unpack_from('<h', payload, 0)[0]}")
+    if len(payload) >= 4:
+        log(f"  [2:4]   solarWat        = {struct.unpack_from('<h', payload, 2)[0]}")
+    if len(payload) >= 6:
+        log(f"  [4:6]   gridWat         = {struct.unpack_from('<h', payload, 4)[0]}")
+    if len(payload) >= 8:
+        log(f"  [6:8]   additionLoadWat = {struct.unpack_from('<h', payload, 6)[0]}")
+    if len(payload) >= 10:
+        log(f"  [8:10]  otherLoadWat    = {struct.unpack_from('<h', payload, 8)[0]}")
+    if len(payload) >= 12:
+        log(f"  [10:12] vechiWat        = {struct.unpack_from('<h', payload, 10)[0]}")
+    if len(payload) >= 14:
+        log(f"  [12:14] ip2Wat          = {struct.unpack_from('<H', payload, 12)[0]}")
+    if len(payload) >= 16:
+        log(f"  [14:16] op2Wat          = {struct.unpack_from('<H', payload, 14)[0]}")
+    if len(payload) >= 17:
+        log(f"  [16]    gridValid       = {payload[16]}")
+    if len(payload) >= 18:
+        log(f"  [17]    bsensorValid    = {payload[17]}")
+    if len(payload) >= 19:
+        log(f"  [18]    solarEfficiency = {payload[18]}")
+    if len(payload) >= 20:
+        log(f"  [19]    thirdpartyPVOn  = {payload[19]}")
+    if len(payload) >= 22:
+        log(f"  [20:22] dualPowerWat    = {struct.unpack_from('<h', payload, 20)[0]}")
+
+
+def read_power_flow(
+    e2e_creds: dict,
+    *,
+    timeout: float = 5.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read realtime power flow via E2E (type 0x30).
+
+    Sends ``GET_GLOBAL_CURRENT_FLOW_INFO`` and returns a dict with
+    ``battery_w``, ``solar_w``, ``grid_w``, ``dual_power_w``, etc.
+    Returns *None* on failure.
+    """
+    session_nonce = generate_nonce()
+
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    power_pkt = build_subscription_packet(
+        e2e_creds, 0x30, session_nonce, payload=bytes([0x01]),
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if log:
+                log(f"{label}: sent {len(pkt)}B → no response")
+            return None
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+
+        resp = _send(power_pkt, "PowerFlow(0x30)")
+        if not resp:
+            return None
+
+        decrypted = decrypt_response(
+            resp, e2e_creds["chat_secret"],
+            payload_validator=_is_power_flow_payload,
+        )
+        if decrypted is not None and log:
+            _log_power_flow_raw(decrypted, log)
+        result = parse_power_flow(decrypted)
+        if result is not None:
+            return result
+
+        # First response may be an echo/ACK; try a few more
+        for _ in range(5):
+            try:
+                resp, _ = sock.recvfrom(4096)
+                decrypted = decrypt_response(
+                    resp, e2e_creds["chat_secret"],
+                    payload_validator=_is_power_flow_payload,
+                )
+                if decrypted is not None and log:
+                    _log_power_flow_raw(decrypted, log)
+                result = parse_power_flow(decrypted)
+                if result is not None:
+                    return result
+            except socket.timeout:
+                break
+
+        return None
     finally:
         sock.close()
 
@@ -1279,83 +1434,265 @@ def set_peak_shaving_redundancy(
     return resp is not None
 
 
-def read_power_flow(
-    e2e_creds: dict,
-    *,
-    timeout: float = 5.0,
-    log: Callable[..., None] | None = None,
-) -> dict | None:
-    """Read realtime power flow via E2E (type 0x30).
+# ---------------------------------------------------------------------------
+# Persistent E2E Session (for real-time polling)
+# ---------------------------------------------------------------------------
 
-    Returns a dict with battery_w, solar_w, grid_w, dual_power_w, etc.
-    Returns None on failure.
-    """
-    session_nonce = generate_nonce()
+class PersistentE2ESession:
+    """Long-lived E2E session that keeps a UDP socket open for fast polling.
 
-    home_alive = build_alive_packet(
-        sender_end_id=e2e_creds["home_end_id"],
-        sender_group_id=e2e_creds["home_group_id"],
-        end_secret=e2e_creds["home_end_secret"],
-    )
-    dev_alive = build_alive_packet(
-        sender_end_id=e2e_creds["sender_end_id"],
-        sender_group_id=e2e_creds["sender_group_id"],
-        end_secret=e2e_creds["sender_end_secret"],
-    )
-    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
-    power_pkt = build_subscription_packet(
-        e2e_creds, 0x30, session_nonce, payload=bytes([0x01]),
-    )
+    The default helpers (``read_power_flow``, ``read_overrides``, etc.) open a
+    new UDP socket and run the full alive→heartbeat handshake for every call.
+    For real-time monitoring this is too expensive.
 
-    host, port = _resolve_host(e2e_creds["host"])
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.settimeout(timeout)
-    addr = (host, port)
+    ``PersistentE2ESession`` performs the handshake once, then keeps the
+    session alive with periodic keepalives. Subsequent action calls reuse the
+    same socket and complete in a single request/response round trip.
 
-    def _send(pkt: bytes, label: str) -> bytes | None:
-        sock.sendto(pkt, addr)
+    The session expires on the relay server after a few minutes without
+    keepalive (status 21204). Call :meth:`keepalive` periodically (every
+    ~15 seconds) from a background thread or asyncio task to prevent this.
+    The session automatically re-runs the handshake on :meth:`read_power_flow`
+    if a 21204 error is detected.
+
+    Typical usage (synchronous)::
+
+        from emaldo import EmaldoClient
+        from emaldo.e2e import PersistentE2ESession
+
+        client = EmaldoClient()
+        client.login(email, password)
+        creds = client.e2e_login(home_id, device_id, model)
+
+        session = PersistentE2ESession(creds)
+        session.connect()
         try:
-            resp, _ = sock.recvfrom(4096)
-            if log:
-                log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
-            return resp
-        except socket.timeout:
-            if log:
-                log(f"{label}: sent {len(pkt)}B → no response")
-            return None
+            data = session.read_power_flow()  # fast — reuses socket
+            print(data)
+        finally:
+            session.close()
 
-    try:
-        _send(home_alive, "Alive(home)")
-        _send(dev_alive, "Alive(device)")
-        _send(heartbeat, "Heartbeat")
+    Typical usage (with background keepalive)::
+
+        import threading
+
+        session = PersistentE2ESession(creds)
+        session.connect()
+
+        def _keepalive_loop():
+            while not session.closed:
+                time.sleep(15)
+                session.keepalive()
+
+        threading.Thread(target=_keepalive_loop, daemon=True).start()
+    """
+
+    #: Keepalive interval in seconds. The relay server times out idle sessions
+    #: after ~3 minutes; 15 seconds provides a generous safety margin.
+    DEFAULT_KEEPALIVE_INTERVAL = 15
+
+    #: Status code returned when the relay has dropped the session.
+    SESSION_EXPIRED_STATUS = 21204
+
+    def __init__(
+        self,
+        e2e_creds: dict,
+        *,
+        timeout: float = 5.0,
+        log: Callable[..., None] | None = None,
+    ) -> None:
+        self._creds = e2e_creds
+        self._timeout = timeout
+        self._log = log
+        self._sock: socket.socket | None = None
+        self._addr: tuple[str, int] | None = None
+        self._session_nonce: str | None = None
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        """True once :meth:`close` has been called."""
+        return self._closed
+
+    @property
+    def connected(self) -> bool:
+        """True when the session has an open socket and valid handshake."""
+        return self._sock is not None and not self._closed
+
+    def connect(self) -> None:
+        """Open the UDP socket and run the alive+heartbeat handshake."""
+        if self._sock is not None:
+            return
+
+        host, port = _resolve_host(self._creds["host"])
+        self._addr = (host, port)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(self._timeout)
+
+        self._session_nonce = generate_nonce()
+        self._do_handshake()
+
+    def _do_handshake(self) -> None:
+        """Run alive(home) + alive(device) + heartbeat."""
+        home_alive = build_alive_packet(
+            sender_end_id=self._creds["home_end_id"],
+            sender_group_id=self._creds["home_group_id"],
+            end_secret=self._creds["home_end_secret"],
+        )
+        dev_alive = build_alive_packet(
+            sender_end_id=self._creds["sender_end_id"],
+            sender_group_id=self._creds["sender_group_id"],
+            end_secret=self._creds["sender_end_secret"],
+        )
+        heartbeat = build_heartbeat_packet(self._creds, self._session_nonce)
+
+        self._send_raw(home_alive, "Alive(home)")
+        self._send_raw(dev_alive, "Alive(device)")
+        self._send_raw(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
-        resp = _send(power_pkt, "PowerFlow(0x30)")
-        if not resp:
+    def keepalive(self) -> bool:
+        """Send a fresh alive+heartbeat to keep the session alive.
+
+        Returns:
+            True on success, False if the session has been dropped or the
+            socket is closed.
+        """
+        if self._sock is None or self._closed:
+            return False
+
+        try:
+            dev_alive = build_alive_packet(
+                sender_end_id=self._creds["sender_end_id"],
+                sender_group_id=self._creds["sender_group_id"],
+                end_secret=self._creds["sender_end_secret"],
+            )
+            heartbeat = build_heartbeat_packet(self._creds, self._session_nonce)
+            self._send_raw(dev_alive, "Keepalive(alive)")
+            self._send_raw(heartbeat, "Keepalive(heartbeat)")
+            return True
+        except Exception as err:  # noqa: BLE001 - best-effort keepalive
+            if self._log:
+                self._log(f"Keepalive failed: {err}")
+            return False
+
+    def read_power_flow(self) -> dict | None:
+        """Read realtime power flow (0x30) over the existing session.
+
+        Automatically re-runs the handshake if the relay has dropped the
+        session (status 21204).
+        """
+        if self._sock is None or self._closed:
+            raise EmaldoE2EError("Session is not connected")
+
+        for attempt in range(2):
+            power_pkt = build_subscription_packet(
+                self._creds, 0x30, self._session_nonce, payload=bytes([0x01]),
+            )
+            resp = self._send_raw(power_pkt, "PowerFlow(0x30)")
+            if resp is None:
+                # Timeout — maybe session expired. Try reconnect once.
+                if attempt == 0:
+                    self._reconnect()
+                    continue
+                return None
+
+            # Check for session-expired status
+            if self._is_session_expired(resp):
+                if self._log:
+                    self._log("Session expired, reconnecting")
+                if attempt == 0:
+                    self._reconnect()
+                    continue
+                return None
+
+            decrypted = decrypt_response(
+                resp, self._creds["chat_secret"],
+                payload_validator=_is_power_flow_payload,
+            )
+            result = parse_power_flow(decrypted)
+            if result is not None:
+                return result
+
+            # Drain a few more in case we got an echo/ACK first
+            for _ in range(5):
+                try:
+                    more_resp, _ = self._sock.recvfrom(4096)
+                    decrypted = decrypt_response(
+                        more_resp, self._creds["chat_secret"],
+                        payload_validator=_is_power_flow_payload,
+                    )
+                    result = parse_power_flow(decrypted)
+                    if result is not None:
+                        return result
+                except socket.timeout:
+                    break
+
             return None
 
-        decrypted = decrypt_response(
-            resp, e2e_creds["chat_secret"],
-            payload_validator=_is_power_flow_payload,
-        )
-        result = parse_power_flow(decrypted)
-        if result is not None:
-            return result
-
-        # First response may be an echo/ACK; try a few more
-        for _ in range(5):
-            try:
-                resp, _ = sock.recvfrom(4096)
-                decrypted = decrypt_response(
-                    resp, e2e_creds["chat_secret"],
-                    payload_validator=_is_power_flow_payload,
-                )
-                result = parse_power_flow(decrypted)
-                if result is not None:
-                    return result
-            except socket.timeout:
-                break
-
         return None
-    finally:
-        sock.close()
+
+    def close(self) -> None:
+        """Close the socket and mark the session closed."""
+        self._closed = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._sock = None
+
+    def _send_raw(self, pkt: bytes, label: str) -> bytes | None:
+        """Send a packet and read one response (no reconnect logic)."""
+        if self._sock is None or self._addr is None:
+            return None
+        self._sock.sendto(pkt, self._addr)
+        try:
+            resp, _ = self._sock.recvfrom(4096)
+            if self._log:
+                self._log(f"{label}: sent {len(pkt)}B → got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if self._log:
+                self._log(f"{label}: sent {len(pkt)}B → no response")
+            return None
+
+    def _reconnect(self) -> None:
+        """Close and re-open the session (used on 21204 or timeout)."""
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._sock = None
+        host, port = _resolve_host(self._creds["host"])
+        self._addr = (host, port)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(self._timeout)
+        self._session_nonce = generate_nonce()
+        self._do_handshake()
+
+    @classmethod
+    def _is_session_expired(cls, resp: bytes) -> bool:
+        """Check if a response contains the 21204 (session expired) status."""
+        if resp is None or len(resp) < 2:
+            return False
+        # Parse the OPTION_STATUS (0xC0) field if present.
+        pos = 1
+        options = 0
+        if resp[0] & 1:
+            while pos + 1 < len(resp):
+                length_byte = resp[pos]
+                vl = length_byte & 0x7F
+                has_more = bool(length_byte & 0x80)
+                if pos + 2 + vl > len(resp):
+                    break
+                opt_type = resp[pos + 1]
+                if opt_type == 0xC0 and vl == 2:
+                    status = int.from_bytes(resp[pos + 2:pos + 4], "big")
+                    return status == cls.SESSION_EXPIRED_STATUS
+                pos += 2 + vl
+                options += 1
+                if not has_more:
+                    break
+        return False

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -1606,31 +1606,50 @@ class PersistentE2ESession:
                     continue
                 return None
 
-            decrypted = decrypt_response(
-                resp, self._creds["chat_secret"],
-                payload_validator=_is_power_flow_payload,
-            )
-            result = parse_power_flow(decrypted)
+            result = self._try_parse_power_flow(resp)
             if result is not None:
                 return result
 
-            # Drain a few more in case we got an echo/ACK first
-            for _ in range(5):
+            # Drain up to 10 more packets in case of interleaved responses
+            # from the keepalive / subscription channel.
+            drained = 0
+            while drained < 10:
                 try:
                     more_resp, _ = self._sock.recvfrom(4096)
-                    decrypted = decrypt_response(
-                        more_resp, self._creds["chat_secret"],
-                        payload_validator=_is_power_flow_payload,
-                    )
-                    result = parse_power_flow(decrypted)
-                    if result is not None:
-                        return result
+                    drained += 1
                 except socket.timeout:
                     break
+                if self._is_session_expired(more_resp):
+                    if self._log:
+                        self._log("Session expired mid-drain, reconnecting")
+                    break
+                result = self._try_parse_power_flow(more_resp)
+                if result is not None:
+                    return result
+
+            # If we still have nothing on the first attempt, force a reconnect
+            # and try once more. This covers the case where the relay has
+            # silently lost our subscription binding.
+            if attempt == 0:
+                if self._log:
+                    self._log("No power flow response after drain, reconnecting")
+                self._reconnect()
+                continue
 
             return None
 
         return None
+
+    def _try_parse_power_flow(self, resp: bytes) -> dict | None:
+        """Decrypt+parse a response as a power flow payload. Returns None on mismatch."""
+        try:
+            decrypted = decrypt_response(
+                resp, self._creds["chat_secret"],
+                payload_validator=_is_power_flow_payload,
+            )
+        except Exception:  # noqa: BLE001 - best-effort parse
+            return None
+        return parse_power_flow(decrypted)
 
     def close(self) -> None:
         """Close the socket and mark the session closed."""

--- a/custom_components/emaldo/number.py
+++ b/custom_components/emaldo/number.py
@@ -1,0 +1,120 @@
+"""Number platform for Emaldo integration.
+
+Exposes the EV "Fixed charge amount" slider as a ``number`` entity. Changes
+are written via the 0x31 ``SET_EVCHARGINGMODE_INSTANT`` command with mode
+set to ``instantChargeFixed`` (mode 5), which mirrors what the Android app
+does when the user drags the slider in the EV panel.
+
+The current value and max bound are both read from the slow coordinator
+(wire byte 0x20 response).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import EmaldoCoordinator
+from .emaldo_lib.e2e import (
+    EV_MODE_INSTANT_FIXED,
+    set_ev_charging_mode_instant,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Emaldo number entities from a config entry."""
+    power_coordinator: EmaldoCoordinator = hass.data[DOMAIN][entry.entry_id]["power"]
+
+    # Only add the EV slider if the device actually reports EV state.
+    ev = (power_coordinator.data or {}).get("ev")
+    if ev is None:
+        _LOGGER.debug("No EV state reported; skipping EV fixed charge number")
+        return
+
+    async_add_entities([EmaldoEvFixedChargeNumber(power_coordinator)])
+
+
+class EmaldoEvFixedChargeNumber(CoordinatorEntity[EmaldoCoordinator], NumberEntity):
+    """Slider entity for EV "Fixed charge amount" (kWh)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "EV fixed charge amount"
+    _attr_icon = "mdi:ev-station"
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = 1
+    _attr_native_step = 1
+
+    def __init__(self, coordinator: EmaldoCoordinator) -> None:
+        """Initialize the slider."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.home_id}_ev_fixed_charge_kwh"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info linking to the main Emaldo device."""
+        c = self.coordinator
+        return DeviceInfo(
+            identifiers={(DOMAIN, c.device_id or c.home_id)},
+            name=c.device_name or "Emaldo Battery",
+            manufacturer="Emaldo",
+            model=c.device_model,
+        )
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the max slider value from the device's ``fixedFull``."""
+        ev = (self.coordinator.data or {}).get("ev") or {}
+        # Fall back to 100 if the device hasn't reported yet; matches
+        # the default slider max observed on PC1-BAK15-HS10.
+        return float(ev.get("fixed_full_kwh") or 100)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the currently stored fixed charge value."""
+        ev = (self.coordinator.data or {}).get("ev") or {}
+        val = ev.get("fixed_kwh")
+        return float(val) if val is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Write a new fixed charge amount to the device.
+
+        Always sends mode=5 (instantChargeFixed) because setting a fixed
+        kWh value while the device is in any other mode would silently
+        drop the write. If the user is currently in a Smart mode, this
+        will also switch the mode — mirroring the behaviour of the
+        official Android app when the slider is dragged.
+        """
+        kwh = int(round(value))
+
+        def _write() -> bool:
+            client = self.coordinator._ensure_client()  # noqa: SLF001
+            creds = client.e2e_login(
+                self.coordinator.home_id,
+                self.coordinator._device_id,  # noqa: SLF001
+                self.coordinator._model,      # noqa: SLF001
+            )
+            return set_ev_charging_mode_instant(
+                creds, EV_MODE_INSTANT_FIXED, fixed_kwh=kwh,
+            )
+
+        ok = await self.hass.async_add_executor_job(_write)
+        if not ok:
+            _LOGGER.warning("EV fixed charge write (%d kWh) was not acknowledged", kwh)
+        # Refresh so the stored state is re-read from the device
+        await self.coordinator.async_request_refresh()

--- a/custom_components/emaldo/select.py
+++ b/custom_components/emaldo/select.py
@@ -2,18 +2,56 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    CONTROL_PRIORITY_INTERNAL,
-    CONTROL_PRIORITY_OVERRIDE,
+from .const import DOMAIN
+from .coordinator import EmaldoCoordinator
+from .emaldo_lib.e2e import (
+    EV_MODE_LOWEST_PRICE,
+    EV_MODE_SCHEDULED,
+    EV_MODE_INSTANT_FULL,
+    EV_MODE_INSTANT_FIXED,
+    set_ev_charging_mode_instant,
+    set_ev_charging_mode_smart,
 )
-from .schedule_coordinator import EmaldoScheduleCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# EV select options, in the order they appear in the Emaldo app.
+# ``Solar Only`` (mode 2) is defined in the APK enum but is not exposed
+# in the current Android app UI on PC1-BAK15-HS10, so we omit it here
+# as well.
+EV_OPTION_LOWEST_PRICE = "Lowest Price"
+EV_OPTION_SCHEDULED = "Scheduled"
+EV_OPTION_INSTANT_FULL = "Until Fully Charged"
+EV_OPTION_INSTANT_FIXED = "Fixed Amount"
+
+EV_OPTIONS = [
+    EV_OPTION_LOWEST_PRICE,
+    EV_OPTION_SCHEDULED,
+    EV_OPTION_INSTANT_FULL,
+    EV_OPTION_INSTANT_FIXED,
+]
+
+# Map mode integer (as returned by ``read_ev_charging_mode``) back to
+# the HA select option label. Mode 2 (Solar Only) maps to None so the
+# select reports "unknown" if the device happens to be in that state.
+_MODE_TO_OPTION: dict[int, str | None] = {
+    EV_MODE_LOWEST_PRICE: EV_OPTION_LOWEST_PRICE,
+    EV_MODE_SCHEDULED: EV_OPTION_SCHEDULED,
+    EV_MODE_INSTANT_FULL: EV_OPTION_INSTANT_FULL,
+    EV_MODE_INSTANT_FIXED: EV_OPTION_INSTANT_FIXED,
+    2: None,  # Solar Only — not exposed in UI
+}
 
 
 async def async_setup_entry(
@@ -22,28 +60,89 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Emaldo select entities from a config entry."""
-    schedule_coordinator: EmaldoScheduleCoordinator = hass.data[DOMAIN][
-        entry.entry_id
-    ]["schedule"]
+    data = hass.data[DOMAIN][entry.entry_id]
+    power_coordinator: EmaldoCoordinator = data["power"]
 
-    async_add_entities([EmaldoControlPrioritySelect(schedule_coordinator)])
+    entities: list[SelectEntity] = []
+
+    # Only add the EV mode select if the device actually reports EV
+    # state (i.e. hardware with an EV charger attached).
+    if (power_coordinator.data or {}).get("ev") is not None:
+        entities.append(EmaldoEvChargeModeSelect(power_coordinator))
+    else:
+        _LOGGER.debug("No EV state reported; skipping EV mode select")
+
+    async_add_entities(entities)
 
 
-class EmaldoControlPrioritySelect(SelectEntity):
-    """Virtual select entity for controlling override priority."""
+# ``EmaldoControlPrioritySelect`` — disabled.
+#
+# Inherited from wertigpar's upstream, this was a stub "virtual" select
+# entity exposing "internal" / "override" priority options. The
+# ``async_select_option`` handler only stored the chosen value in memory
+# and didn't propagate anywhere — no service, coordinator, or other file
+# in the integration ever read it. Keeping it visible in the UI was
+# confusing because it looked functional, so we disable it until/unless
+# someone wires up real behavior behind it.
+#
+# class EmaldoControlPrioritySelect(SelectEntity):
+#     _attr_has_entity_name = True
+#     _attr_name = "Control priority"
+#     _attr_options = [CONTROL_PRIORITY_INTERNAL, CONTROL_PRIORITY_OVERRIDE]
+#     _attr_current_option = CONTROL_PRIORITY_INTERNAL
+#
+#     def __init__(self, coordinator: EmaldoScheduleCoordinator) -> None:
+#         self._coordinator = coordinator
+#         self._attr_unique_id = f"{coordinator.home_id}_control_priority"
+#
+#     @property
+#     def device_info(self) -> DeviceInfo:
+#         c = self._coordinator
+#         return DeviceInfo(
+#             identifiers={(DOMAIN, c.device_id or c.home_id)},
+#             name=c.device_name or "Emaldo Battery",
+#             manufacturer="Emaldo",
+#             model=c.device_model,
+#         )
+#
+#     async def async_select_option(self, option: str) -> None:
+#         self._attr_current_option = option
+#         self.async_write_ha_state()
+
+
+class EmaldoEvChargeModeSelect(CoordinatorEntity[EmaldoCoordinator], SelectEntity):
+    """Dropdown for EV charging mode.
+
+    Read: current mode is taken from the slow coordinator's ``ev`` dict
+    (wire byte 0x20 response), mapped through :data:`_MODE_TO_OPTION`.
+
+    Write: each option sends the matching setter over E2E:
+      - "Lowest Price"        → ``set_ev_charging_mode_smart(1)``
+      - "Scheduled"           → ``set_ev_charging_mode_smart(3, ...)``
+        (Reuses the stored weekday/weekend bitmaps from the slow
+        coordinator so switching to Scheduled doesn't wipe the existing
+        schedule. Edit the schedule via the ``emaldo.set_ev_schedule``
+        service.)
+      - "Until Fully Charged" → ``set_ev_charging_mode_instant(4)``
+      - "Fixed Amount"        → ``set_ev_charging_mode_instant(5, fixed_kwh=...)``
+        (Uses the current ``fixed_kwh`` value from the device; to change
+        the kWh amount, use the ``number`` slider entity.)
+    """
 
     _attr_has_entity_name = True
-    _attr_name = "Control priority"
-    _attr_options = [CONTROL_PRIORITY_INTERNAL, CONTROL_PRIORITY_OVERRIDE]
-    _attr_current_option = CONTROL_PRIORITY_INTERNAL
+    _attr_name = "EV charge mode"
+    _attr_icon = "mdi:ev-station"
+    _attr_options = EV_OPTIONS
 
-    def __init__(self, coordinator: EmaldoScheduleCoordinator) -> None:
-        self._coordinator = coordinator
-        self._attr_unique_id = f"{coordinator.home_id}_control_priority"
+    def __init__(self, coordinator: EmaldoCoordinator) -> None:
+        """Initialize the EV mode select."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.home_id}_ev_charge_mode"
 
     @property
     def device_info(self) -> DeviceInfo:
-        c = self._coordinator
+        """Return device info linking to the main Emaldo device."""
+        c = self.coordinator
         return DeviceInfo(
             identifiers={(DOMAIN, c.device_id or c.home_id)},
             name=c.device_name or "Emaldo Battery",
@@ -51,7 +150,48 @@ class EmaldoControlPrioritySelect(SelectEntity):
             model=c.device_model,
         )
 
+    @property
+    def current_option(self) -> str | None:
+        """Return the current mode from the coordinator state."""
+        ev = (self.coordinator.data or {}).get("ev") or {}
+        return _MODE_TO_OPTION.get(ev.get("mode"))
+
     async def async_select_option(self, option: str) -> None:
-        """Handle option selection."""
-        self._attr_current_option = option
-        self.async_write_ha_state()
+        """Write the new mode to the device."""
+        _LOGGER.debug("EV select: async_select_option called with %r", option)
+        ev = (self.coordinator.data or {}).get("ev") or {}
+
+        def _write() -> bool:
+            client = self.coordinator._ensure_client()  # noqa: SLF001
+            creds = client.e2e_login(
+                self.coordinator.home_id,
+                self.coordinator._device_id,  # noqa: SLF001
+                self.coordinator._model,      # noqa: SLF001
+            )
+            if option == EV_OPTION_LOWEST_PRICE:
+                return set_ev_charging_mode_smart(creds, EV_MODE_LOWEST_PRICE)
+            if option == EV_OPTION_SCHEDULED:
+                # Reuse stored hour bitmaps so switching modes doesn't
+                # wipe the schedule.
+                return set_ev_charging_mode_smart(
+                    creds, EV_MODE_SCHEDULED,
+                    weekdays=ev.get("weekdays"),
+                    weekend=ev.get("weekend"),
+                    sync=bool(ev.get("sync")),
+                )
+            if option == EV_OPTION_INSTANT_FULL:
+                return set_ev_charging_mode_instant(creds, EV_MODE_INSTANT_FULL)
+            if option == EV_OPTION_INSTANT_FIXED:
+                # Reuse the currently stored fixed value; users adjust it
+                # via the EmaldoEvFixedChargeNumber slider.
+                return set_ev_charging_mode_instant(
+                    creds, EV_MODE_INSTANT_FIXED,
+                    fixed_kwh=int(ev.get("fixed_kwh") or 0),
+                )
+            _LOGGER.warning("Unknown EV option: %s", option)
+            return False
+
+        ok = await self.hass.async_add_executor_job(_write)
+        if not ok:
+            _LOGGER.warning("EV mode write (%s) was not acknowledged", option)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -191,9 +191,16 @@ def _solar_power(data: dict[str, Any]) -> float | None:
 
 
 def _car_charge_power(data: dict[str, Any]) -> float | None:
-    """EV charger power in W (Power Core only)."""
+    """EV charger power in W — positive = charging the car (Power Core only).
+
+    The Emaldo wire value reports EV load as negative (a sink from the home
+    node's POV). We flip it so the sensor reads as a positive load, matching
+    the Consumption sensor convention and user expectations for "car charge
+    power" (0 = idle, positive = drawing power).
+    """
     if isinstance(data, dict):
-        return data.get("ev_w")
+        w = data.get("ev_w")
+        return -w if w is not None else None
     return None
 
 

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -229,7 +229,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         name="Battery charged today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_battery_charged_today,
     ),
     EmaldoSensorEntityDescription(
@@ -237,7 +237,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         name="Battery discharged today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_battery_discharged_today,
     ),
     EmaldoSensorEntityDescription(
@@ -246,7 +246,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         icon="mdi:solar-power",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_solar_energy_today,
     ),
     EmaldoSensorEntityDescription(
@@ -255,7 +255,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         icon="mdi:transmission-tower-import",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_grid_import_today,
     ),
     EmaldoSensorEntityDescription(
@@ -264,7 +264,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         icon="mdi:transmission-tower-export",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_grid_export_today,
     ),
     EmaldoSensorEntityDescription(
@@ -273,7 +273,7 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         icon="mdi:home-lightning-bolt",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_load_energy_today,
     ),
 )

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -89,41 +89,36 @@ def _battery_discharged_today(data: dict[str, Any]) -> float | None:
 
 def _battery_power(data: dict[str, Any]) -> float | None:
     """Battery power in W (positive = charging, negative = discharging)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("battery_w")
+    if isinstance(data, dict):
+        return data.get("battery_w")
     return None
 
 
 def _grid_power(data: dict[str, Any]) -> float | None:
     """Grid power in W (positive = importing, negative = exporting)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("grid_w")
+    if isinstance(data, dict):
+        return data.get("grid_w")
     return None
 
 
 def _dual_power(data: dict[str, Any]) -> float | None:
     """Building consumption in W (negative = consuming)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("dual_power_w")
+    if isinstance(data, dict):
+        return data.get("dual_power_w")
     return None
 
 
 def _solar_power(data: dict[str, Any]) -> float | None:
     """Solar PV power in W (Power Core only)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("solar_w")
+    if isinstance(data, dict):
+        return data.get("solar_w")
     return None
 
 
 def _car_charge_power(data: dict[str, Any]) -> float | None:
     """EV charger power in W (Power Core only)."""
-    pf = data.get("power_flow")
-    if isinstance(pf, dict):
-        return pf.get("ev_w")
+    if isinstance(data, dict):
+        return data.get("ev_w")
     return None
 
 
@@ -137,7 +132,8 @@ class EmaldoSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[dict[str, Any]], float | None]
 
 
-SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
+# Sensors that read from the slow REST coordinator (battery + energy totals)
+REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_soc",
         name="Battery SoC",
@@ -162,6 +158,10 @@ SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         value_fn=_battery_discharged_today,
     ),
+)
+
+# Sensors that read from the fast E2E realtime coordinator (power flow)
+REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_power",
         name="Battery power",
@@ -188,8 +188,8 @@ SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     ),
 )
 
-# Sensors only available on Power Core models (PC1-BAK15-HS10, PC3)
-POWER_CORE_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
+# Power Core only (PC1-BAK15-HS10, PC3) — also from realtime coordinator
+POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="solar_power",
         name="Solar power",
@@ -217,19 +217,26 @@ async def async_setup_entry(
     """Set up Emaldo sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator: EmaldoCoordinator = data["power"]
+    realtime_coordinator = data["realtime"]
     schedule_coordinator: EmaldoScheduleCoordinator = data["schedule"]
 
     entities: list[SensorEntity] = [
         EmaldoSensor(coordinator, description)
-        for description in SENSOR_DESCRIPTIONS
+        for description in REST_SENSOR_DESCRIPTIONS
     ]
 
-    # Power Core models have built-in solar PV and EV charger
+    # Real-time power sensors come from the E2E coordinator
+    entities.extend(
+        EmaldoSensor(realtime_coordinator, description)
+        for description in REALTIME_SENSOR_DESCRIPTIONS
+    )
+
+    # Power Core models have built-in solar PV and EV charger — also realtime
     model = coordinator.device_model or ""
     if model.startswith("PC"):
         entities.extend(
-            EmaldoSensor(coordinator, desc)
-            for desc in POWER_CORE_SENSOR_DESCRIPTIONS
+            EmaldoSensor(realtime_coordinator, desc)
+            for desc in POWER_CORE_REALTIME_DESCRIPTIONS
         )
 
     entities.append(EmaldoPlanSourceSensor(schedule_coordinator))

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -87,6 +87,59 @@ def _battery_discharged_today(data: dict[str, Any]) -> float | None:
     return round(total * 5 / 60 / 1000, 2)
 
 
+def _sum_series(series: dict | None, column: int, interval_min: int = 5) -> float | None:
+    """Sum a column from a 5-minute-interval power series and return kWh."""
+    if not isinstance(series, dict):
+        return None
+    entries = series.get("data", [])
+    if not entries:
+        return None
+    total = sum(e[column] for e in entries if len(e) > column)
+    return round(total * interval_min / 60 / 1000, 3)
+
+
+def _solar_energy_today(data: dict[str, Any]) -> float | None:
+    """Total solar energy produced today (sum of all MPPT strings)."""
+    solar_resp = data.get("solar")
+    if not isinstance(solar_resp, dict):
+        return None
+    series = solar_resp.get("mppt") if "mppt" in solar_resp else solar_resp
+    if not isinstance(series, dict):
+        return None
+    entries = series.get("data", [])
+    if not entries:
+        return None
+    # Sum all columns except the first (time offset)
+    ncols = len(entries[0]) - 1 if entries else 0
+    total = sum(
+        sum(e[i + 1] for i in range(ncols) if len(e) > i + 1)
+        for e in entries
+    )
+    return round(total * 5 / 60 / 1000, 3)
+
+
+def _grid_import_today(data: dict[str, Any]) -> float | None:
+    """Total grid import energy today.
+
+    The grid stats endpoint with ``get_real=True`` returns 13 columns per row:
+    ``[time_offset, import_W, ?, export_W, ?, phantom_W, 0, ...]``.
+    """
+    grid_resp = data.get("power", {}).get("grid")
+    return _sum_series(grid_resp, column=1)
+
+
+def _grid_export_today(data: dict[str, Any]) -> float | None:
+    """Total grid export energy today (col[3] of grid stats with get_real)."""
+    grid_resp = data.get("power", {}).get("grid")
+    return _sum_series(grid_resp, column=3)
+
+
+def _load_energy_today(data: dict[str, Any]) -> float | None:
+    """Total property load energy today (col[2] of usage stats)."""
+    usage_resp = data.get("power", {}).get("usage")
+    return _sum_series(usage_resp, column=2)
+
+
 def _battery_power(data: dict[str, Any]) -> float | None:
     """Battery power in W (positive = charging, negative = discharging)."""
     if isinstance(data, dict):
@@ -158,6 +211,42 @@ REST_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         value_fn=_battery_discharged_today,
     ),
+    EmaldoSensorEntityDescription(
+        key="solar_energy_today",
+        name="Solar energy today",
+        icon="mdi:solar-power",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_solar_energy_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="grid_import_today",
+        name="Grid import today",
+        icon="mdi:transmission-tower-import",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_grid_import_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="grid_export_today",
+        name="Grid export today",
+        icon="mdi:transmission-tower-export",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_grid_export_today,
+    ),
+    EmaldoSensorEntityDescription(
+        key="load_energy_today",
+        name="Load energy today",
+        icon="mdi:home-lightning-bolt",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=_load_energy_today,
+    ),
 )
 
 # Sensors that read from the fast E2E realtime coordinator (power flow)
@@ -165,6 +254,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="battery_power",
         name="Battery power",
+        icon="mdi:battery-charging",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -173,6 +263,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="grid_power",
         name="Grid power",
+        icon="mdi:transmission-tower",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -181,6 +272,7 @@ REALTIME_SENSOR_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="dual_power",
         name="Consumption",
+        icon="mdi:home-lightning-bolt",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -193,6 +285,7 @@ POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="solar_power",
         name="Solar power",
+        icon="mdi:solar-power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -201,6 +294,7 @@ POWER_CORE_REALTIME_DESCRIPTIONS: tuple[EmaldoSensorEntityDescription, ...] = (
     EmaldoSensorEntityDescription(
         key="car_charge_power",
         name="Car charge power",
+        icon="mdi:car-electric",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -141,23 +142,38 @@ def _load_energy_today(data: dict[str, Any]) -> float | None:
 
 
 def _battery_power(data: dict[str, Any]) -> float | None:
-    """Battery power in W (positive = charging, negative = discharging)."""
+    """Battery power in W — HA Energy Dashboard "Standard" convention.
+
+    HA is house-centric: positive = flowing *into* the house, so positive
+    means the battery is *discharging* (feeding home) and negative means
+    *charging*. The Emaldo wire value already matches this, so we pass it
+    through unchanged. Users can select "Standard" in the Energy Dashboard
+    battery setup without needing the "Inverted" option.
+    """
     if isinstance(data, dict):
         return data.get("battery_w")
     return None
 
 
 def _grid_power(data: dict[str, Any]) -> float | None:
-    """Grid power in W (positive = importing, negative = exporting)."""
+    """Grid power in W — HA convention: positive = importing, negative = exporting.
+
+    The Emaldo wire value already matches this convention.
+    """
     if isinstance(data, dict):
         return data.get("grid_w")
     return None
 
 
 def _dual_power(data: dict[str, Any]) -> float | None:
-    """Building consumption in W (negative = consuming)."""
+    """Home consumption in W — HA convention: positive = consuming.
+
+    The Emaldo wire value reports consumption as negative (a sink from the
+    home node's POV). We flip it so the sensor reads as a positive load.
+    """
     if isinstance(data, dict):
-        return data.get("dual_power_w")
+        w = data.get("dual_power_w")
+        return -w if w is not None else None
     return None
 
 
@@ -332,6 +348,9 @@ async def async_setup_entry(
             EmaldoSensor(realtime_coordinator, desc)
             for desc in POWER_CORE_REALTIME_DESCRIPTIONS
         )
+
+    # Diagnostic: realtime connection status
+    entities.append(EmaldoRealtimeStatusSensor(realtime_coordinator))
 
     entities.append(EmaldoPlanSourceSensor(schedule_coordinator))
     entities.append(EmaldoActiveModeSensor(schedule_coordinator))
@@ -656,4 +675,77 @@ class EmaldoScheduleChartSensor(
             "schedule": sched_data,
             "slot_count": len(slots),
             "gap_minutes": gap,
+        }
+
+
+class EmaldoRealtimeStatusSensor(SensorEntity):
+    """Diagnostic sensor showing E2E realtime connection health."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Realtime connection"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:lan-connect"
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the diagnostic sensor."""
+        self._coordinator = coordinator
+        self._attr_unique_id = f"{coordinator.home_id}_realtime_status"
+
+    async def async_added_to_hass(self) -> None:
+        """Register for coordinator updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Update state when coordinator refreshes."""
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._coordinator.home_id)}
+            if not self._coordinator.device_id
+            else {(DOMAIN, self._coordinator.device_id)},
+            name=self._coordinator.device_name or "Emaldo Battery",
+            manufacturer="Emaldo",
+            model=self._coordinator.device_model,
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return current connection state."""
+        if self._coordinator.last_update_success:
+            return "connected"
+        return "reconnecting"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return statistics about the realtime connection."""
+        import datetime
+        c = self._coordinator
+
+        def _to_iso(ts: float | None) -> str | None:
+            if ts is None:
+                return None
+            return datetime.datetime.fromtimestamp(ts).isoformat()
+
+        success_rate = None
+        if c.stats_total_polls > 0:
+            success_rate = round(
+                100.0 * c.stats_successful_polls / c.stats_total_polls, 1
+            )
+
+        return {
+            "total_polls": c.stats_total_polls,
+            "successful_polls": c.stats_successful_polls,
+            "success_rate_pct": success_rate,
+            "empty_reads": c.stats_empty_reads,
+            "reconnects": c.stats_reconnects,
+            "keepalive_failures": c.stats_keepalive_failures,
+            "last_success": _to_iso(c.stats_last_success),
+            "last_failure": _to_iso(c.stats_last_failure),
+            "last_reconnect": _to_iso(c.stats_last_reconnect),
         }

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -67,13 +67,19 @@ def _battery_soc(data: dict[str, Any]) -> float | None:
 
 
 def _battery_charged_today(data: dict[str, Any]) -> float | None:
+    """Total battery charge energy today in kWh.
+
+    The ``/bmt/stats/battery-v2/day/`` response has 6 columns per entry:
+    [minute_offset, discharge_W, charge_main_W, charge_aux_W, unused, state].
+    Charge is the sum of columns 2 (main, solar) and 3 (auxiliary/grid).
+    """
     bat_data = data.get("battery", {}).get("battery", {})
     if not isinstance(bat_data, dict):
         return None
     entries = bat_data.get("data", [])
     if not entries:
         return None
-    total = sum(e[3] + e[4] for e in entries if len(e) >= 5)
+    total = sum(e[2] + e[3] for e in entries if len(e) >= 4)
     return round(total * 5 / 60 / 1000, 2)
 
 

--- a/custom_components/emaldo/services.py
+++ b/custom_components/emaldo/services.py
@@ -16,6 +16,10 @@ from .emaldo_lib.const import (
     DEFAULT_MARKER_LOW,
     encode_override_action,
 )
+from .emaldo_lib.e2e import (
+    EV_MODE_SCHEDULED,
+    set_ev_charging_mode_smart,
+)
 from .emaldo_lib.exceptions import EmaldoAuthError
 
 from .const import DOMAIN
@@ -37,6 +41,7 @@ SERVICE_SET_SLOT_RANGE = "set_slot_range"
 SERVICE_APPLY_BULK_SCHEDULE = "apply_bulk_schedule"
 SERVICE_RESET_TO_INTERNAL = "reset_to_internal"
 SERVICE_REFRESH_SCHEDULE = "refresh_schedule"
+SERVICE_SET_EV_SCHEDULE = "set_ev_schedule"
 
 SCHEMA_SET_SLOT_RANGE = vol.Schema(
     {
@@ -64,6 +69,20 @@ SCHEMA_APPLY_BULK_SCHEDULE = vol.Schema(
         vol.Optional("low_marker", default=DEFAULT_MARKER_LOW): vol.All(
             int, vol.Range(min=1, max=100)
         ),
+    }
+)
+
+SCHEMA_SET_EV_SCHEDULE = vol.Schema(
+    {
+        # Lists of hour integers 0-23 when EV charging is allowed.
+        # Empty list or omitted key means "no hours selected".
+        vol.Optional("weekdays", default=list): vol.All(
+            [vol.All(int, vol.Range(min=0, max=23))],
+        ),
+        vol.Optional("weekend", default=list): vol.All(
+            [vol.All(int, vol.Range(min=0, max=23))],
+        ),
+        vol.Optional("sync", default=False): cv.boolean,
     }
 )
 
@@ -282,6 +301,73 @@ async def async_handle_refresh_schedule(
         await coord.async_request_refresh()
 
 
+async def async_handle_set_ev_schedule(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Handle the set_ev_schedule service call.
+
+    Sets the EV charger's weekday and weekend hour schedule (when
+    charging is allowed). This switches the device into
+    ``EV_MODE_SCHEDULED`` and writes the 24h×2 hour bitmaps via the
+    ``SET_EV_CHARGING_MODE`` command (wire 0x22, 9-byte payload).
+
+    Input lists are hours 0-23 — e.g. ``[6, 7, 22, 23]`` enables
+    charging 06:00-08:00 and 22:00-00:00. Empty lists disable all hours
+    for that day type (which effectively means "never charge on that
+    day"; prefer picking a different mode instead).
+    """
+    weekday_hours = call.data.get("weekdays", [])
+    weekend_hours = call.data.get("weekend", [])
+    sync = call.data.get("sync", False)
+
+    weekdays = [0] * 24
+    for h in weekday_hours:
+        weekdays[h] = 1
+    weekend = [0] * 24
+    for h in weekend_hours:
+        weekend[h] = 1
+
+    def _do_set():
+        entries = hass.data.get(DOMAIN, {})
+        if not entries:
+            raise ValueError("No Emaldo integration configured")
+        entry_data = next(iter(entries.values()))
+        power_coord = entry_data["power"]
+        for attempt in range(2):
+            try:
+                client = power_coord._ensure_client()  # noqa: SLF001
+                creds = client.e2e_login(
+                    power_coord.home_id,
+                    power_coord._device_id,  # noqa: SLF001
+                    power_coord._model,      # noqa: SLF001
+                )
+                return set_ev_charging_mode_smart(
+                    creds, EV_MODE_SCHEDULED,
+                    weekdays=weekdays, weekend=weekend, sync=sync,
+                )
+            except EmaldoAuthError:
+                if attempt == 0:
+                    _LOGGER.debug("Session expired, re-authenticating")
+                    power_coord._client = None  # noqa: SLF001
+                else:
+                    raise
+
+    ok = await hass.async_add_executor_job(_do_set)
+    if ok:
+        _LOGGER.info(
+            "EV schedule applied: weekdays=%s, weekend=%s, sync=%s",
+            weekday_hours, weekend_hours, sync,
+        )
+    else:
+        _LOGGER.warning("EV schedule write was not acknowledged")
+
+    # Refresh the slow coordinator so the new schedule is reflected in
+    # the select / number / sensor entities.
+    entries = hass.data.get(DOMAIN, {})
+    for entry_data in entries.values():
+        await entry_data["power"].async_request_refresh()
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register Emaldo services."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_SLOT_RANGE):
@@ -298,6 +384,9 @@ def async_register_services(hass: HomeAssistant) -> None:
 
     async def handle_refresh_schedule(call: ServiceCall) -> None:
         await async_handle_refresh_schedule(hass, call)
+
+    async def handle_set_ev_schedule(call: ServiceCall) -> None:
+        await async_handle_set_ev_schedule(hass, call)
 
     hass.services.async_register(
         DOMAIN,
@@ -322,6 +411,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         SERVICE_REFRESH_SCHEDULE,
         handle_refresh_schedule,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_EV_SCHEDULE,
+        handle_set_ev_schedule,
+        schema=SCHEMA_SET_EV_SCHEDULE,
+    )
 
 
 def async_unregister_services(hass: HomeAssistant) -> None:
@@ -331,3 +426,4 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         hass.services.async_remove(DOMAIN, SERVICE_APPLY_BULK_SCHEDULE)
         hass.services.async_remove(DOMAIN, SERVICE_RESET_TO_INTERNAL)
         hass.services.async_remove(DOMAIN, SERVICE_REFRESH_SCHEDULE)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_EV_SCHEDULE)

--- a/custom_components/emaldo/services.yaml
+++ b/custom_components/emaldo/services.yaml
@@ -124,3 +124,30 @@ reset_to_internal:
 refresh_schedule:
   name: Refresh schedule
   description: Manually trigger a schedule and override data refresh.
+
+set_ev_schedule:
+  name: Set EV charging schedule
+  description: >
+    Switches the EV charger to Smart → Scheduled mode and writes weekday
+    and weekend hour bitmaps. Each list contains hour integers 0-23
+    when charging is allowed; empty list = no hours selected for that
+    day type.
+  fields:
+    weekdays:
+      name: Weekday hours
+      description: "List of hour integers 0-23 when EV charging is allowed on weekdays."
+      example: "[6, 7, 22, 23]"
+      selector:
+        object:
+    weekend:
+      name: Weekend hours
+      description: "List of hour integers 0-23 when EV charging is allowed on weekends."
+      example: "[10, 11, 12]"
+      selector:
+        object:
+    sync:
+      name: Sync to other devices
+      description: Mirror the app's "Sync" toggle (propagates schedule to other devices in the home).
+      default: false
+      selector:
+        boolean:


### PR DESCRIPTION
## Summary

Adds real-time power monitoring, HA Energy Dashboard support, EV charging mode control, and several data fixes.

### Real-time E2E power coordinator
- **EmaldoRealtimeCoordinator** polls power flow every 10s via `PersistentE2ESession` (persistent UDP, ~85ms per read)
- Tolerates up to 3 consecutive empty reads before reconnecting (keeps previous values visible to sensors)
- Diagnostic sensor `sensor.<device>_realtime_connection` with stats (polls, success rate, reconnects, keepalive failures)
- WARNING-level logging for drops and reconnects (no DEBUG needed to see drop frequency)

### Energy Dashboard sensors
- `solar_energy_today`, `grid_import_today`, `grid_export_today`, `load_energy_today` — daily kWh from REST stats
- All daily sensors use `state_class=TOTAL_INCREASING` to handle midnight resets correctly (fixes -33 kWh negative values on day boundaries)

### Power sensor sign conventions
- Battery power: raw wire (positive = discharging, negative = charging) — matches HA Energy Dashboard "Standard"
- Consumption: flipped to positive-when-consuming (HA convention for load sensors)
- Car charge power: flipped to positive-when-charging
- Grid power: unchanged (already matches HA Standard: positive = import, negative = export)

### EV charging mode control
- **`select.<device>_ev_charge_mode`** — Lowest Price / Scheduled / Until Fully Charged / Fixed Amount
- **`number.<device>_ev_fixed_charge_amount`** — kWh slider (0 to device max, typically 100)
- **`emaldo.set_ev_schedule` service** — takes weekday/weekend hour lists for Scheduled mode
- Reads current state from device every coordinator cycle (wire bytes 0x20/0x21)
- Writes use the matching setter (wire 0x22 for Smart modes, 0x31 for Instant modes)

### Bug fixes
- **battery_charged_today column mapping** — was summing col[3]+col[4] (wrong), now col[2]+col[3] (correct). Previously reported 2.73 kWh vs actual 15.2 kWh.
- **daily energy sensors** — TOTAL → TOTAL_INCREASING to fix negative kWh on day boundaries
- **EmaldoControlPrioritySelect** — commented out (was a non-functional stub with a broken import that prevented SELECT platform from loading)
- **SELECT and NUMBER platforms** — added to PLATFORMS list (select.py existed but was dead code)

### Depends on
- wertigpar/emaldo_python#2 (PersistentE2ESession + EV charging mode support in the library)

## Test plan

- [x] Realtime coordinator: 99.1% success rate over 1700+ polls, automatic reconnect
- [x] Energy Dashboard: all kWh sensors positive and increasing, no negative values at midnight
- [x] Power signs: battery/grid/consumption/car match HA standard conventions
- [x] Battery charged today: 15.2 kWh matches Emaldo app (was 2.73 before fix)
- [x] EV mode select: Lowest Price, Scheduled (with hour bitmaps), Instant Fixed (with kWh slider) — all verified against live device
- [x] EV read: wire byte 0x20 returns mode + fixed values, confirmed round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)