### PR TITLE
fix: add support for 3rd party pv on power store

### DIFF
--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -138,10 +138,6 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             _LOGGER.debug("Solar stats fetch failed: %s", err)
 
-        # Debug: log battery-v2 column breakdown once per update (debug level only)
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            self._log_battery_v2_sample(battery)
-
         # EV charging mode + schedule — best-effort, only Power Core
         # hardware (with EV charger) exposes these commands. Errors are
         # swallowed so a device without EV support doesn't break the
@@ -160,29 +156,6 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "solar": solar,
             "ev": ev,
         }
-
-    @staticmethod
-    def _log_battery_v2_sample(battery: dict) -> None:
-        """Log a sample of raw battery-v2 data for diagnosing column layout."""
-        entries = battery.get("battery", {}).get("data", [])
-        if not entries:
-            return
-        # Find a non-zero entry for meaningful output
-        sample = next((e for e in entries if len(e) >= 4 and any(v != 0 for v in e[1:])), entries[0])
-        ncols = len(sample)
-        _LOGGER.debug(
-            "battery-v2 sample entry (%d cols): %s | "
-            "col1=discharge col2=charge_main col3=charge_aux col4=%s",
-            ncols,
-            sample,
-            sample[4] if ncols > 4 else "n/a",
-        )
-        # Log per-column sums (useful for identifying which column carries PS solar charge)
-        col_sums = [sum(e[i] for e in entries if len(e) > i) for i in range(1, 6)]
-        _LOGGER.debug(
-            "battery-v2 column sums (raw W·intervals) col1..5: %s",
-            col_sums,
-        )
 
     def _read_ev_state(self) -> dict | None:
         """Read EV charging mode (wire 0x20) and schedule (wire 0x21).

--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -138,6 +138,10 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             _LOGGER.debug("Solar stats fetch failed: %s", err)
 
+        # Debug: log battery-v2 column breakdown once per update (debug level only)
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            self._log_battery_v2_sample(battery)
+
         # EV charging mode + schedule — best-effort, only Power Core
         # hardware (with EV charger) exposes these commands. Errors are
         # swallowed so a device without EV support doesn't break the
@@ -156,6 +160,29 @@ class EmaldoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "solar": solar,
             "ev": ev,
         }
+
+    @staticmethod
+    def _log_battery_v2_sample(battery: dict) -> None:
+        """Log a sample of raw battery-v2 data for diagnosing column layout."""
+        entries = battery.get("battery", {}).get("data", [])
+        if not entries:
+            return
+        # Find a non-zero entry for meaningful output
+        sample = next((e for e in entries if len(e) >= 4 and any(v != 0 for v in e[1:])), entries[0])
+        ncols = len(sample)
+        _LOGGER.debug(
+            "battery-v2 sample entry (%d cols): %s | "
+            "col1=discharge col2=charge_main col3=charge_aux col4=%s",
+            ncols,
+            sample,
+            sample[4] if ncols > 4 else "n/a",
+        )
+        # Log per-column sums (useful for identifying which column carries PS solar charge)
+        col_sums = [sum(e[i] for e in entries if len(e) > i) for i in range(1, 6)]
+        _LOGGER.debug(
+            "battery-v2 column sums (raw W·intervals) col1..5: %s",
+            col_sums,
+        )
 
     def _read_ev_state(self) -> dict | None:
         """Read EV charging mode (wire 0x20) and schedule (wire 0x21).

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -69,9 +69,21 @@ def _battery_soc(data: dict[str, Any]) -> float | None:
 def _battery_charged_today(data: dict[str, Any]) -> float | None:
     """Total battery charge energy today in kWh.
 
-    The ``/bmt/stats/battery-v2/day/`` response has 6 columns per entry:
-    [minute_offset, discharge_W, charge_main_W, charge_aux_W, unused, state].
-    Charge is the sum of columns 2 (main, solar) and 3 (auxiliary/grid).
+    The ``/bmt/stats/battery-v2/day/`` response has at least 6 columns:
+    [minute_offset, discharge_W, charge_main_W, charge_aux_W, charge_ac_W, state].
+
+    For **Power Core** (internal MPPT solar):
+      col 2 = solar MPPT → battery DC charge
+      col 3 = grid → battery AC charge
+      col 4 = 0 (unused, no separate AC-bus channel)
+
+    For **Power Store** (external/third-party solar inverter on the AC bus):
+      col 2 = 0 (no internal MPPT)
+      col 3 = grid-direct battery charge only
+      col 4 = solar-sourced AC-bus battery charge (this is the missing energy)
+
+    Summing cols 2 + 3 + 4 is safe for both models: Power Core sees col 4 = 0,
+    while Power Store gets the full AC-bus charge included.
     """
     bat_data = data.get("battery", {}).get("battery", {})
     if not isinstance(bat_data, dict):
@@ -79,7 +91,11 @@ def _battery_charged_today(data: dict[str, Any]) -> float | None:
     entries = bat_data.get("data", [])
     if not entries:
         return None
-    total = sum(e[2] + e[3] for e in entries if len(e) >= 4)
+    total = sum(
+        e[2] + e[3] + (e[4] if len(e) > 4 else 0)
+        for e in entries
+        if len(e) >= 4
+    )
     return round(total * 5 / 60 / 1000, 2)
 
 
@@ -405,6 +421,26 @@ class EmaldoSensor(CoordinatorEntity[EmaldoCoordinator], SensorEntity):
         if self.coordinator.data is None:
             return None
         return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return per-column charge breakdown for battery_charged_today (diagnostic)."""
+        if self.entity_description.key != "battery_charged_today":
+            return None
+        if self.coordinator.data is None:
+            return None
+        bat_data = self.coordinator.data.get("battery", {}).get("battery", {})
+        if not isinstance(bat_data, dict):
+            return None
+        entries = bat_data.get("data", [])
+        if not entries:
+            return None
+        factor = 5 / 60 / 1000
+        return {
+            "col2_charge_main_kwh": round(sum(e[2] for e in entries if len(e) > 2) * factor, 3),
+            "col3_charge_aux_kwh": round(sum(e[3] for e in entries if len(e) > 3) * factor, 3),
+            "col4_charge_ac_kwh": round(sum(e[4] for e in entries if len(e) > 4) * factor, 3),
+        }
 
 
 # -- Helper to compute current slot index --

--- a/custom_components/emaldo/sensor.py
+++ b/custom_components/emaldo/sensor.py
@@ -422,26 +422,6 @@ class EmaldoSensor(CoordinatorEntity[EmaldoCoordinator], SensorEntity):
             return None
         return self.entity_description.value_fn(self.coordinator.data)
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return per-column charge breakdown for battery_charged_today (diagnostic)."""
-        if self.entity_description.key != "battery_charged_today":
-            return None
-        if self.coordinator.data is None:
-            return None
-        bat_data = self.coordinator.data.get("battery", {}).get("battery", {})
-        if not isinstance(bat_data, dict):
-            return None
-        entries = bat_data.get("data", [])
-        if not entries:
-            return None
-        factor = 5 / 60 / 1000
-        return {
-            "col2_charge_main_kwh": round(sum(e[2] for e in entries if len(e) > 2) * factor, 3),
-            "col3_charge_aux_kwh": round(sum(e[3] for e in entries if len(e) > 3) * factor, 3),
-            "col4_charge_ac_kwh": round(sum(e[4] for e in entries if len(e) > 4) * factor, 3),
-        }
-
 
 # -- Helper to compute current slot index --
 


### PR DESCRIPTION
So I have Emaldo Power Store and a separate 3rd party PV system. Without this change the "Battery Charged today" sensor will count only grid energy. 
<img width="471" height="984" alt="image" src="https://github.com/user-attachments/assets/03358f77-b5d6-4000-af2d-c9a3b98ff306" />
