### PR TITLE
Fix send_sell semantics, add correct manual-selling commands, plus fixes from pylenius fork

### DIFF
--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -348,13 +348,13 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
             self._empty_reads = 0
             self.stats_last_failure = _time.time()
             _LOGGER.warning("E2E auth failed, will re-login on next poll: %s", err)
-            raise UpdateFailed(f"E2E auth failed: {err}") from err
+            return self.data  # keep last known values visible
         except Exception as err:
             await self._close_session()
             self._empty_reads = 0
             self.stats_last_failure = _time.time()
             _LOGGER.warning("E2E power flow read failed: %s", err)
-            raise UpdateFailed(f"E2E power flow read failed: {err}") from err
+            return self.data  # keep last known values visible
 
         # Ensure keepalive task is running
         if self._keepalive_task is None or self._keepalive_task.done():
@@ -378,7 +378,7 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
                 )
                 await self._close_session()
                 self._empty_reads = 0
-                raise UpdateFailed("No power flow data returned")
+                return self.data  # keep last known values visible
             # Keep previous data visible to sensors
             _LOGGER.info(
                 "E2E power flow empty read %d/%d, keeping previous values",

--- a/custom_components/emaldo/emaldo_lib/client.py
+++ b/custom_components/emaldo/emaldo_lib/client.py
@@ -346,6 +346,50 @@ class EmaldoClient:
             return data.get("bmts", [])
         return []
 
+    def get_manual_selling_history(
+        self,
+        home_id: str,
+        device_id: str,
+        *,
+        page_size: int = 20,
+        before_unix: int | None = None,
+    ) -> dict:
+        """List past manual-selling (grid-export) sessions.
+
+        REST endpoint, not MSCT. Response::
+
+            {
+              "total": 4, "page": 0, "page_size": N, "total_pages": 1,
+              "records": [
+                {"power": 0.3, "end_time": 1776504071},   # kWh sold, unix seconds
+                ...
+              ]
+            }
+
+        ``power`` is energy in kWh despite the misleading field name
+        (inherited from the APK).
+
+        Args:
+            home_id: Home identifier.
+            device_id: BMT device id.
+            page_size: How many records to fetch (1..100).
+            before_unix: Cursor — fetch sessions that ended strictly before
+                this unix timestamp. None ⇒ now.
+        """
+        import time as _time
+        end = before_unix if before_unix is not None else int(_time.time())
+        result = self.api_request(
+            "/bmt/get-manual-selling-history/",
+            json_data={
+                "home_id": home_id,
+                "bmt_id": device_id,
+                "end_time": end,
+                "page_size": page_size,
+            },
+        )
+        data = result.get("Result", {})
+        return data if isinstance(data, dict) else {}
+
     def search_device(self, home_id: str, device_id: str, model: str) -> dict:
         """Search for a specific device and return detailed info."""
         json_data = {

--- a/custom_components/emaldo/emaldo_lib/client.py
+++ b/custom_components/emaldo/emaldo_lib/client.py
@@ -427,6 +427,10 @@ class EmaldoClient:
     ) -> dict:
         """Get comprehensive daily usage data.
 
+        Args:
+            offset: Day offset. 0 = today, negative = past days
+                (-1 = yesterday, -2 = day before, etc.).
+
         Returns a dict with keys: ``usage``, ``battery``, ``solar``, ``grid``, ``power_level``.
         """
         base = {"home_id": home_id, "id": device_id, "model": model, "offset": offset}
@@ -453,7 +457,12 @@ class EmaldoClient:
     def get_revenue(
         self, home_id: str, device_id: str, model: str, offset: int = 0
     ) -> dict:
-        """Get daily revenue data."""
+        """Get daily revenue data.
+
+        Args:
+            offset: Day offset. 0 = today, negative = past days
+                (-1 = yesterday, -2 = day before, etc.).
+        """
         json_data = {
             "home_id": home_id,
             "id": device_id,
@@ -521,7 +530,13 @@ class EmaldoClient:
     def get_solar(
         self, home_id: str, device_id: str, model: str, offset: int = 0
     ) -> dict:
-        """Get solar/MPPT generation data."""
+        """Get solar/MPPT generation data (5-min intervals, 288 points/day).
+
+        Args:
+            offset: Day offset. 0 = today, negative = past days
+                (-1 = yesterday, -2 = day before, etc.).
+                At least 30 days of history available.
+        """
         json_data = {
             "home_id": home_id,
             "id": device_id,
@@ -534,7 +549,12 @@ class EmaldoClient:
     def get_grid(
         self, home_id: str, device_id: str, model: str, offset: int = 0
     ) -> dict:
-        """Get grid import/export data."""
+        """Get grid import/export data (5-min intervals).
+
+        Args:
+            offset: Day offset. 0 = today, negative = past days
+                (-1 = yesterday, -2 = day before, etc.).
+        """
         json_data = {
             "home_id": home_id,
             "id": device_id,

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -138,21 +138,23 @@ def build_subscription_packet(
 
     mode_byte = 0x10 if request_mode else 0xA0
 
-    pkt = bytes([0xD9, 0xA0, 0xA0])
+    # Option order matches module_bmt/yd/e.java:93:
+    # END_ID, GROUP_ID, RECEIVER_ID, AES, PROXY(1B), APP_ID, METHOD(2B), MSGID, CT
+    pkt = bytes([0xD9, 0xA0, 0xA0])                 # header + END_ID (cont)
     pkt += e2e_creds["sender_end_id"].encode()
-    pkt += bytes([0xA0, 0xA1])
+    pkt += bytes([0xA0, 0xA1])                      # GROUP_ID (cont)
     pkt += e2e_creds["sender_group_id"].encode()
-    pkt += bytes([0x84, 0xF1, 0x00, 0x00, 0x00, 0x01])
-    pkt += bytes([0xA0, 0xA2])
+    pkt += bytes([0xA0, 0xA2])                      # RECEIVER_ID (cont)
     pkt += e2e_creds["recipient_end_id"].encode()
-    pkt += bytes([0x90, 0xA3])
+    pkt += bytes([0x90, 0xA3])                      # AES nonce (cont)
     pkt += nonce.encode()
-    pkt += bytes([0xA0, 0xB5])
+    pkt += bytes([0x81, 0xF1, 0x01])                # PROXY (1B, cont) — was 4B
+    pkt += bytes([0xA0, 0xB5])                      # APP_ID (cont)
     pkt += get_app_id().encode()
-    pkt += bytes([0x82, 0xF5, msg_type])
-    pkt += bytes([mode_byte, 0x9B, 0xF6])
+    pkt += bytes([0x82, 0xF5, msg_type, mode_byte]) # METHOD (2B, cont)
+    pkt += bytes([0x9B, 0xF6])                      # MSGID (cont)
     pkt += msg_id.encode()
-    pkt += bytes([0x10, 0xB7])
+    pkt += bytes([0x10, 0xB7])                      # CT (LAST)
     pkt += b"application/byte"
     pkt += encrypted
     return pkt
@@ -200,7 +202,54 @@ def build_heartbeat_packet(
     session_nonce: str,
     msg_id: str | None = None,
 ) -> bytes:
-    """Build a heartbeat packet (251 bytes)."""
+    """Build a heartbeat packet.
+
+    Option order mirrors module_bmt/yd/e.java:231 exactly:
+        END_ID, GROUP_ID, RECEIVER_ID, AES, PROXY(1B), METHOD, APP_ID, MSGID, CT
+    The previous 4-byte PROXY (0x84 0xF1 00 00 00 01) and RECEIVER_ID-before-AES
+    layout caused the relay to reject commands with status 0x52D4.
+    """
+    if msg_id is None:
+        msg_id = generate_msg_id()
+
+    assert len(session_nonce) == 16
+    assert len(msg_id) == 27
+
+    payload_json = json.dumps(
+        {"__time": int(time.time())}, separators=(",", ":")
+    ).encode()
+    encrypted = encrypt_payload(payload_json, e2e_creds["chat_secret"], session_nonce)
+
+    pkt = bytes([0xD9, 0xA0, 0xA0])                 # header + END_ID (len 32, cont)
+    pkt += e2e_creds["sender_end_id"].encode()
+    pkt += bytes([0xA0, 0xA1])                      # GROUP_ID (len 32, cont)
+    pkt += e2e_creds["sender_group_id"].encode()
+    pkt += bytes([0xA0, 0xA2])                      # RECEIVER_ID (len 32, cont)
+    pkt += e2e_creds["recipient_end_id"].encode()
+    pkt += bytes([0x90, 0xA3])                      # AES nonce (len 16, cont)
+    pkt += session_nonce.encode()
+    pkt += bytes([0x81, 0xF1, 0x01])                # PROXY (len 1, cont) — was 4B
+    pkt += bytes([0x89, 0xF5])                      # METHOD "heartbeat" (len 9, cont)
+    pkt += b"heartbeat"
+    pkt += bytes([0xA0, 0xB5])                      # APP_ID (len 32, cont)
+    pkt += get_app_id().encode()
+    pkt += bytes([0x9B, 0xF6])                      # MSGID (len 27, cont)
+    pkt += msg_id.encode()
+    pkt += bytes([0x10, 0xB7])                      # CT (len 16, LAST)
+    pkt += b"application/json"
+    pkt += encrypted
+    return pkt
+
+
+def build_wake_packet(
+    e2e_creds: dict,
+    session_nonce: str,
+    msg_id: str | None = None,
+) -> bytes:
+    """Build a wake packet — nudges the relay's per-session routing table for
+    the device. Mirrors module_bmt/x/n.java:223 (setIsNeedResult=false in APK,
+    so a status=1 reply is tolerated — it's fire-and-forget).
+    """
     if msg_id is None:
         msg_id = generate_msg_id()
 
@@ -216,19 +265,17 @@ def build_heartbeat_packet(
     pkt += e2e_creds["sender_end_id"].encode()
     pkt += bytes([0xA0, 0xA1])
     pkt += e2e_creds["sender_group_id"].encode()
-    pkt += bytes([0x84, 0xF1, 0x00, 0x00, 0x00, 0x01])
     pkt += bytes([0xA0, 0xA2])
     pkt += e2e_creds["recipient_end_id"].encode()
     pkt += bytes([0x90, 0xA3])
     pkt += session_nonce.encode()
-    pkt += bytes([0x89, 0xF5])
-    pkt += b"heartbeat"
+    pkt += bytes([0x81, 0xF1, 0x01])
+    pkt += bytes([0x84, 0xF5])                      # METHOD "wake" (len 4, cont)
+    pkt += b"wake"
     pkt += bytes([0xA0, 0xB5])
     pkt += get_app_id().encode()
-    pkt += bytes([0x9B, 0xF6])
+    pkt += bytes([0x1B, 0xF6])                      # MSGID (len 27, LAST)
     pkt += msg_id.encode()
-    pkt += bytes([0x10, 0xB7])
-    pkt += b"application/json"
     pkt += encrypted
     return pkt
 
@@ -608,6 +655,7 @@ def _run_session(
         nonce=dev_alive_nonce,
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
 
     host, port = _resolve_host(e2e_creds["host"])
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -630,6 +678,7 @@ def _run_session(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -671,6 +720,7 @@ def read_overrides(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
     sub_pkt = build_subscription_packet(e2e_creds, 0x1B, session_nonce)
 
     host, port = _resolve_host(e2e_creds["host"])
@@ -693,6 +743,7 @@ def read_overrides(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -756,6 +807,7 @@ def read_battery_info(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
 
     host, port = _resolve_host(e2e_creds["host"])
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -788,6 +840,7 @@ def read_battery_info(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -900,6 +953,7 @@ def read_power_flow(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
     power_pkt = build_subscription_packet(
         e2e_creds, 0x30, session_nonce, payload=bytes([0x01]),
     )
@@ -924,6 +978,7 @@ def read_power_flow(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -989,6 +1044,7 @@ def send_override(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
     override_pkt = build_override_packet(
         e2e_creds, slot_values, nonce=session_nonce,
         high_marker=high_marker, low_marker=low_marker,
@@ -1014,6 +1070,7 @@ def send_override(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -1064,6 +1121,7 @@ def send_sell(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
     sell_pkt = build_subscription_packet(
         e2e_creds, 0x01, session_nonce,
         payload=payload,
@@ -1089,6 +1147,7 @@ def send_sell(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -1126,6 +1185,7 @@ def cancel_sell(
         end_secret=e2e_creds["sender_end_secret"],
     )
     heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
     cancel_pkt = build_subscription_packet(
         e2e_creds, 0x01, session_nonce,
         payload=payload,
@@ -1151,6 +1211,7 @@ def cancel_sell(
     try:
         _send(home_alive, "Alive(home)")
         _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
         _send(heartbeat, "Heartbeat")
         time.sleep(0.2)
 
@@ -1158,6 +1219,241 @@ def cancel_sell(
         if resp and len(resp) == 161:
             return True
         return resp is not None
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# Emergency charge (pull energy FROM grid) and Manual selling (push TO grid)
+# ---------------------------------------------------------------------------
+#
+# NOTE on the legacy `send_sell` / `cancel_sell` above: those send opcode 0x01A0,
+# which the APK calls SET_EMERGENCY_CHARGE — i.e. charge the battery from the
+# grid, NOT sell to the grid. The functions below use the correct semantics.
+# Opcodes:
+#   0x01A0  set_emergency_charge   write [on u8, start u32le, end u32le]  9B
+#   0x80A0  set_manual_selling     write [on u8, target_kwh u32le, expand u8] 6B
+#   0x81A0  get_manual_selling     read  [firstUse u8, enabled u8,
+#                                         target_0.1kWh u32le, sold_0.1kWh u32le] 10B
+
+
+def set_emergency_charge(
+    e2e_creds: dict,
+    on: bool,
+    *,
+    start_unix: int | None = None,
+    end_unix: int | None = None,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Enable/disable emergency charging over a time window.
+
+    When enabling, the default window is now → top-of-current-hour + 48 h,
+    matching the APK default in ``module_bmt/m7/f.java:846``.
+    """
+    if on:
+        if start_unix is None:
+            start_unix = int(time.time())
+        if end_unix is None:
+            now = time.time()
+            end_unix = int(now - (int(now) % 3600)) + 172800
+        payload = struct.pack("<BII", 1, start_unix, end_unix)
+    else:
+        payload = bytes(9)  # 9 zeros
+
+    session_nonce = generate_nonce()
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
+    cmd_pkt = build_subscription_packet(
+        e2e_creds, 0x01, session_nonce, payload=payload,
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B \u2192 got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if log:
+                log(f"{label}: sent {len(pkt)}B \u2192 no response")
+            return None
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+        resp = _send(cmd_pkt, "EmergencyCharge")
+        return resp is not None
+    finally:
+        sock.close()
+
+
+def set_manual_selling(
+    e2e_creds: dict,
+    on: bool,
+    target_energy_kwh: int | float = 0,
+    *,
+    expand: bool = False,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Start/stop grid-export (manual selling) with a cumulative kWh target.
+
+    The inverter exports until ``target_energy_kwh`` total have been sold,
+    then stops automatically. Use :func:`get_manual_selling` to poll
+    progress. Opcode 0x80A0 (APK case 18 via ``g(map)``).
+
+    Wire:
+        [on u8, target_kwh u32 LE, isExpandSelling u8] — 6 bytes total.
+    """
+    if on and target_energy_kwh <= 0:
+        raise ValueError("target_energy_kwh must be > 0 when enabling")
+    target = round(target_energy_kwh) if on else 0
+    payload = struct.pack("<BIB", 1 if on else 0, target & 0xFFFFFFFF, 1 if expand else 0)
+
+    session_nonce = generate_nonce()
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
+    cmd_pkt = build_subscription_packet(
+        e2e_creds, 0x80, session_nonce, payload=payload,
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B \u2192 got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            return None
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+        resp = _send(cmd_pkt, "ManualSelling")
+        return resp is not None
+    finally:
+        sock.close()
+
+
+def parse_manual_selling_response(payload: bytes | None) -> dict | None:
+    """Decode the 10-byte GET_MANUAL_SELLING response payload.
+
+    Returns dict with ``enabled``, ``first_use``, ``target_energy_kwh``,
+    ``sold_so_far_kwh``, ``remaining_kwh``.
+    """
+    if payload is None or len(payload) < 10:
+        return None
+    first_use = payload[0] == 1
+    enabled = payload[1] == 1
+    target_deci = int.from_bytes(payload[2:6], "little", signed=False)
+    sold_deci = int.from_bytes(payload[6:10], "little", signed=False)
+    return {
+        "first_use": first_use,
+        "enabled": enabled,
+        "target_energy_kwh": round(target_deci / 10.0, 2),
+        "sold_so_far_kwh": round(sold_deci / 10.0, 2),
+        "remaining_kwh": round(max(0, target_deci - sold_deci) / 10.0, 2),
+    }
+
+
+def get_manual_selling(
+    e2e_creds: dict,
+    *,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read current manual-selling state + energy counters (opcode 0x81A0).
+
+    See :func:`parse_manual_selling_response` for field semantics. Returns
+    *None* if the session handshake or decryption fails.
+    """
+    session_nonce = generate_nonce()
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
+    cmd_pkt = build_subscription_packet(
+        e2e_creds, 0x81, session_nonce, payload=b"",
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B \u2192 got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            return None
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+        resp = _send(cmd_pkt, "GetManualSelling")
+        if not resp:
+            return None
+        # Match the pattern used by other readers: decrypt with chat_secret,
+        # accept any payload >= 10 bytes.
+        decrypted = decrypt_response(
+            resp, e2e_creds["chat_secret"],
+            payload_validator=lambda b: len(b) >= 10,
+        )
+        return parse_manual_selling_response(decrypted)
     finally:
         sock.close()
 
@@ -1912,9 +2208,11 @@ class PersistentE2ESession:
             end_secret=self._creds["sender_end_secret"],
         )
         heartbeat = build_heartbeat_packet(self._creds, self._session_nonce)
+        wake = build_wake_packet(self._creds, self._session_nonce)
 
         self._send_raw(home_alive, "Alive(home)")
         self._send_raw(dev_alive, "Alive(device)")
+        self._send_raw(wake, "Wake")
         self._send_raw(heartbeat, "Heartbeat")
         time.sleep(0.2)
 

--- a/custom_components/emaldo/services.py
+++ b/custom_components/emaldo/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import voluptuous as vol
@@ -42,6 +43,7 @@ SERVICE_APPLY_BULK_SCHEDULE = "apply_bulk_schedule"
 SERVICE_RESET_TO_INTERNAL = "reset_to_internal"
 SERVICE_REFRESH_SCHEDULE = "refresh_schedule"
 SERVICE_SET_EV_SCHEDULE = "set_ev_schedule"
+SERVICE_BACKFILL_SOLAR = "backfill_solar"
 
 SCHEMA_SET_SLOT_RANGE = vol.Schema(
     {
@@ -83,6 +85,14 @@ SCHEMA_SET_EV_SCHEDULE = vol.Schema(
             [vol.All(int, vol.Range(min=0, max=23))],
         ),
         vol.Optional("sync", default=False): cv.boolean,
+    }
+)
+
+SCHEMA_BACKFILL_SOLAR = vol.Schema(
+    {
+        vol.Optional("days", default=30): vol.All(
+            int, vol.Range(min=1, max=90)
+        ),
     }
 )
 
@@ -368,6 +378,193 @@ async def async_handle_set_ev_schedule(
         await entry_data["power"].async_request_refresh()
 
 
+async def async_handle_backfill_solar(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Backfill solar energy statistics from Emaldo API history.
+
+    Fetches up to 90 days of 5-min MPPT data using negative offsets,
+    aggregates to hourly statistics, and imports them via
+    async_add_external_statistics so they appear in the Energy Dashboard.
+
+    To avoid double-counting, the backfill finds the earliest date the
+    live solar_energy_today sensor has statistics for and only imports
+    days before that. Any previous backfill data is cleared first.
+    """
+    from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+    from homeassistant.components.recorder.statistics import (
+        async_add_external_statistics,
+    )
+    from homeassistant.components.recorder import get_instance
+
+    days = call.data.get("days", 30)
+    statistic_id = f"{DOMAIN}:solar_energy_backfill"
+
+    # Find cutoff: earliest date the live solar_energy_today sensor
+    # has state history, so we don't overlap with real data.
+    cutoff_date = None
+    try:
+        for state in hass.states.async_all("sensor"):
+            if "solar_energy_today" in state.entity_id:
+                # Check entity registry for when it was added,
+                # or use the entity's first recorded state.
+                from homeassistant.components.recorder.history import (
+                    get_significant_states,
+                )
+                now = datetime.now(timezone.utc)
+                start = now - timedelta(days=days + 1)
+                history = await get_instance(hass).async_add_executor_job(
+                    get_significant_states,
+                    hass, start, now, [state.entity_id],
+                )
+                if history.get(state.entity_id):
+                    first_ts = history[state.entity_id][0].last_changed
+                    cutoff_date = first_ts.date()
+                    _LOGGER.info(
+                        "Backfill solar: live sensor %s first seen %s, "
+                        "will only backfill before that date",
+                        state.entity_id, cutoff_date,
+                    )
+                break
+    except Exception:
+        _LOGGER.debug("Backfill: could not determine live sensor cutoff", exc_info=True)
+
+    # Clear previous backfill data
+    try:
+        recorder_instance = get_instance(hass)
+        # Try the available clear API
+        try:
+            from homeassistant.components.recorder.statistics import (
+                clear_statistics,
+            )
+            await recorder_instance.async_add_executor_job(
+                clear_statistics, recorder_instance, [statistic_id]
+            )
+        except ImportError:
+            from homeassistant.components.recorder.statistics import (
+                async_clear_statistics,
+            )
+            async_clear_statistics(recorder_instance, [statistic_id])
+        _LOGGER.info("Backfill solar: cleared previous backfill data")
+    except Exception:
+        _LOGGER.debug(
+            "Backfill: no previous data to clear or clear not available",
+            exc_info=True,
+        )
+
+    # Get client
+    entries = hass.data.get(DOMAIN, {})
+    if not entries:
+        raise ValueError("No Emaldo integration configured")
+    entry_data = next(iter(entries.values()))
+    power_coord = entry_data["power"]
+
+    today = datetime.now().date()
+
+    def _fetch_history():
+        client = power_coord._ensure_client()  # noqa: SLF001
+        hid = power_coord.home_id
+        did = power_coord._device_id  # noqa: SLF001
+        model = power_coord._model  # noqa: SLF001
+
+        all_days = {}
+        for day_offset in range(-1, -days, -1):  # skip today (offset=0)
+            day_date = today + timedelta(days=day_offset)
+            # Stop if we'd overlap with live sensor data
+            if cutoff_date and day_date >= cutoff_date:
+                _LOGGER.debug(
+                    "Backfill: skipping %s (live sensor has data)", day_date
+                )
+                continue
+            try:
+                result = client.get_solar(hid, did, model, offset=day_offset)
+                data = result.get("data", [])
+                start_time = result.get("start_time", 0)
+                tz_name = result.get("timezone", "Europe/Helsinki")
+                if data:
+                    all_days[day_offset] = {
+                        "data": data,
+                        "start_time": start_time,
+                        "timezone": tz_name,
+                    }
+                    total_w = sum(sum(e[1:]) for e in data)
+                    kwh = total_w * 5 / 60 / 1000
+                    _LOGGER.info(
+                        "Backfill solar: %s (offset=%d), %d pts, %.1f kWh",
+                        day_date, day_offset, len(data), kwh,
+                    )
+            except Exception:
+                _LOGGER.exception("Backfill: failed to fetch offset=%d", day_offset)
+        return all_days
+
+    _LOGGER.info("Backfill solar: fetching up to %d days of history...", days)
+    all_days = await hass.async_add_executor_job(_fetch_history)
+
+    if not all_days:
+        _LOGGER.warning("Backfill solar: no data to import (all days overlap with live sensor)")
+        return
+
+    # Aggregate to hourly statistics
+    import zoneinfo
+
+    hourly_stats: list[StatisticData] = []
+    cumulative_kwh = 0.0
+
+    for day_offset in sorted(all_days.keys()):
+        day_data = all_days[day_offset]
+        day_entries = day_data["data"]
+        start_time = day_data["start_time"]
+        tz_name = day_data["timezone"]
+
+        # Group by hour
+        hourly_wh: dict[int, float] = {}
+        for entry in day_entries:
+            minute_offset = entry[0]
+            total_w = sum(entry[1:])
+            wh = total_w * 5 / 60  # 5-min interval → Wh
+            hour = minute_offset // 60
+            hourly_wh[hour] = hourly_wh.get(hour, 0) + wh
+
+        day_start = datetime.fromtimestamp(start_time, tz=timezone.utc)
+        for hour in sorted(hourly_wh.keys()):
+            if hour > 23:
+                continue
+            kwh = hourly_wh[hour] / 1000
+            cumulative_kwh += kwh
+            hour_start = day_start.replace(
+                hour=hour, minute=0, second=0, microsecond=0
+            )
+            hourly_stats.append(
+                StatisticData(
+                    start=hour_start,
+                    state=cumulative_kwh,
+                    sum=cumulative_kwh,
+                )
+            )
+
+    if not hourly_stats:
+        _LOGGER.warning("Backfill solar: no hourly stats to import")
+        return
+
+    metadata = StatisticMetaData(
+        has_mean=False,
+        has_sum=True,
+        name="Solar energy (backfill)",
+        source=DOMAIN,
+        statistic_id=statistic_id,
+        unit_of_measurement="kWh",
+    )
+
+    first_date = (today + timedelta(days=min(all_days.keys()))).isoformat()
+    last_date = (today + timedelta(days=max(all_days.keys()))).isoformat()
+    _LOGGER.info(
+        "Backfill solar: importing %d hourly stats, %s to %s (%.1f kWh)",
+        len(hourly_stats), first_date, last_date, cumulative_kwh,
+    )
+    async_add_external_statistics(hass, metadata, hourly_stats)
+    _LOGGER.info("Backfill solar: done")
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register Emaldo services."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_SLOT_RANGE):
@@ -387,6 +584,9 @@ def async_register_services(hass: HomeAssistant) -> None:
 
     async def handle_set_ev_schedule(call: ServiceCall) -> None:
         await async_handle_set_ev_schedule(hass, call)
+
+    async def handle_backfill_solar(call: ServiceCall) -> None:
+        await async_handle_backfill_solar(hass, call)
 
     hass.services.async_register(
         DOMAIN,
@@ -417,6 +617,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         handle_set_ev_schedule,
         schema=SCHEMA_SET_EV_SCHEDULE,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BACKFILL_SOLAR,
+        handle_backfill_solar,
+        schema=SCHEMA_BACKFILL_SOLAR,
+    )
 
 
 def async_unregister_services(hass: HomeAssistant) -> None:
@@ -427,3 +633,4 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         hass.services.async_remove(DOMAIN, SERVICE_RESET_TO_INTERNAL)
         hass.services.async_remove(DOMAIN, SERVICE_REFRESH_SCHEDULE)
         hass.services.async_remove(DOMAIN, SERVICE_SET_EV_SCHEDULE)
+        hass.services.async_remove(DOMAIN, SERVICE_BACKFILL_SOLAR)

--- a/custom_components/emaldo/services.yaml
+++ b/custom_components/emaldo/services.yaml
@@ -151,3 +151,21 @@ set_ev_schedule:
       default: false
       selector:
         boolean:
+
+backfill_solar:
+  name: Backfill solar energy history
+  description: >
+    Fetches up to 30 days of historical solar production data from the
+    Emaldo API and imports it as long-term statistics in Home Assistant.
+    The backfilled data appears in the Energy Dashboard under
+    "emaldo:solar_energy_backfill". Run once after initial setup.
+  fields:
+    days:
+      name: Days
+      description: "Number of days to backfill (1-90, default 30)."
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 90
+          step: 1


### PR DESCRIPTION
Consolidated PR from the `pylenius/ha-emaldo-w` fork. Closes #5.

## The headline fix (see #5)

`send_sell` / `cancel_sell` actually invoke opcode `0x01A0` which the APK
calls `SET_EMERGENCY_CHARGE` — i.e. **charge battery from grid**, the
opposite of what their names and docstrings claim. This PR leaves those
two functions alone for back-compat but adds correctly-named siblings:

- `set_emergency_charge(creds, on, start_unix?, end_unix?)` — opcode `0x01A0`, 9-byte payload. What `send_sell` actually did.
- `set_manual_selling(creds, on, target_energy_kwh, expand?)` — opcode `0x80A0`, 6-byte payload. **The real grid-export command** (APK case 18 via `g(map)`, `module_bmt/zd/j.java:3434`).
- `get_manual_selling(creds)` — opcode `0x81A0`, 10-byte response. Returns `{firstUse, enabled, target_energy_kwh, sold_so_far_kwh, remaining_kwh}`.
- `EmaldoClient.get_manual_selling_history(...)` — REST `/bmt/get-manual-selling-history/` — list of past sell sessions as `{power: kWh_sold, end_time: unix_secs}`.

A code comment flags the `send_sell` / `cancel_sell` semantics so future readers don't get bit.

### Verification

Tested live against a `PC1-BAK15-HS10` (“Power Core 2.0”):

```
SET ON target=2 kWh → readback {enabled=true, target=2.0, sold=0.0, remaining=2.0}
SET OFF             → readback {enabled=false, target=0.0, sold=0.0}
history page        → records match the Android app's Sale History screen
```

### Units gotcha (documented in code)

The APK variable `presetPower` in the manual-selling flow is actually an **energy target in kWh**, not a power in watts. The slider in the app is a kWh slider. Confirmed by the `X.Y kWh / N kWh` labels in the app's Sale History screen. The read path reports the same field in 0.1 kWh units (`wc/b0.java:89` divides by 10 before display).

## Fixes also rolled up from the fork

Pre-existing commits on `pylenius:main` that weren't upstream yet:

- **Prevent sensor dropouts on poll errors** (`095d6c2`) — coordinator doesn't zero-out values on a single failed poll.
- **Add `backfill_solar` service** (`bbbc142`) — populates historical solar statistics via the negative API offset (`offset=-1` = yesterday, etc.). Includes `services.py` + `services.yaml`.

## Files touched

```
custom_components/emaldo/coordinator.py       |   6 +-
custom_components/emaldo/emaldo_lib/client.py |  70 +++++-
custom_components/emaldo/emaldo_lib/e2e.py    | 330 ++++++++++++++++++++++++--
custom_components/emaldo/services.py          | 207 ++++++++++++++++
custom_components/emaldo/services.yaml        |  18 ++
```

## Test plan
- [x] Parses (`python -m py_compile` on all files)
- [x] Deployed to a live HA instance; coordinator polls succeed; no regressions in existing sensors
- [x] `set_manual_selling` / `get_manual_selling` / `get_manual_selling_history` round-trip against a real device
- [x] Sale History records in `get_manual_selling_history` match the Android app's screen byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)