### PR TITLE
Add AI Battery Range control (number + switch + service)

### DIFF
--- a/custom_components/emaldo/__init__.py
+++ b/custom_components/emaldo/__init__.py
@@ -15,6 +15,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SELECT,
     Platform.NUMBER,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/emaldo/emaldo_lib/client.py
+++ b/custom_components/emaldo/emaldo_lib/client.py
@@ -768,6 +768,7 @@ class EmaldoClient:
         *,
         high_marker: int = DEFAULT_MARKER_HIGH,
         low_marker: int = DEFAULT_MARKER_LOW,
+        battery_range_override: bool = False,
         log: Callable[..., None] | None = None,
     ) -> bool:
         """Send override values to the device.
@@ -783,6 +784,9 @@ class EmaldoClient:
             slot_values: 96 bytes of override values.
             high_marker: High battery marker percentage.
             low_marker: Low battery marker percentage.
+            battery_range_override: When ``True`` activates the app's
+                "Battery Range = override" mode (byte 2 of payload). Default
+                ``False`` leaves the AI Battery Range setting unchanged.
             log: Optional log callback ``log(message: str)``.
 
         Returns:
@@ -793,7 +797,8 @@ class EmaldoClient:
         creds = self.e2e_login(home_id, device_id, model)
         return _e2e.send_override(
             creds, slot_values,
-            high_marker=high_marker, low_marker=low_marker, log=log,
+            high_marker=high_marker, low_marker=low_marker,
+            battery_range_override=battery_range_override, log=log,
         )
 
     def reset_overrides(
@@ -804,13 +809,45 @@ class EmaldoClient:
         *,
         high_marker: int = DEFAULT_MARKER_HIGH,
         low_marker: int = DEFAULT_MARKER_LOW,
+        battery_range_override: bool = False,
         log: Callable[..., None] | None = None,
     ) -> bool:
         """Clear all overrides (all slots → follow base schedule)."""
         slot_values = bytes([SLOT_NO_OVERRIDE] * 96)
         return self.set_override(
             home_id, device_id, model, slot_values,
-            high_marker=high_marker, low_marker=low_marker, log=log,
+            high_marker=high_marker, low_marker=low_marker,
+            battery_range_override=battery_range_override, log=log,
+        )
+
+    def set_battery_range(
+        self,
+        home_id: str,
+        device_id: str,
+        model: str,
+        *,
+        smart_pct: int,
+        emergency_pct: int,
+        enable: bool = True,
+        log: Callable[..., None] | None = None,
+    ) -> bool:
+        """Write the AI Battery Range — opcode 0x1AA0 with `enable` byte.
+
+        Mirrors the app's "Save Battery Range" button: sends the new
+        smart/emergency markers with all 96 per-slot overrides cleared to
+        ``SLOT_NO_OVERRIDE`` (0x80). ``enable=True`` activates
+        "Battery Range = override" — AI must operate inside
+        [emergency_pct, smart_pct]. ``enable=False`` reverts to AI-chosen
+        range while persisting the markers.
+        """
+        if not (0 <= smart_pct <= 100 and 0 <= emergency_pct <= 100):
+            raise ValueError("smart_pct and emergency_pct must be 0..100")
+        if smart_pct < emergency_pct:
+            raise ValueError("smart_pct must be >= emergency_pct")
+        return self.reset_overrides(
+            home_id, device_id, model,
+            high_marker=smart_pct, low_marker=emergency_pct,
+            battery_range_override=enable, log=log,
         )
 
     # ── Sell (discharge-to-grid) ──────────────────────────────────────

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -63,6 +63,7 @@ def build_override_packet(
     *,
     high_marker: int = DEFAULT_MARKER_HIGH,
     low_marker: int = DEFAULT_MARKER_LOW,
+    battery_range_override: bool = False,
 ) -> bytes:
     """Build an E2E override UDP packet (type 0x1a).
 
@@ -73,6 +74,11 @@ def build_override_packet(
         msg_id: 27-char message ID (generated if *None*).
         high_marker: High battery marker percentage (default 72).
         low_marker: Low battery marker percentage (default 20).
+        battery_range_override: When ``True`` sets byte 2 to 0x01 — this is
+            the "AI Battery Range = override" flag that the app's Battery
+            Range save sends (BmtCmd.SET_RESERVE_MODE_AI). When ``False``
+            (default) byte 2 is 0x00 → Battery Range stays in AI mode and
+            only the per-slot overrides apply.
 
     Returns:
         Complete UDP packet ready to send.
@@ -88,8 +94,9 @@ def build_override_packet(
     assert len(msg_id) == 27
 
     # Payload: 4-byte header + slot bytes
-    # Header: [high_marker, low_marker, version_flag, slot_count]
-    override_payload = bytes([high_marker, low_marker, 0x00, n_slots]) + slot_values
+    # Header: [high_marker, low_marker, enable_flag, slot_count]
+    enable_byte = 0x01 if battery_range_override else 0x00
+    override_payload = bytes([high_marker, low_marker, enable_byte, n_slots]) + slot_values
     encrypted = encrypt_payload(override_payload, e2e_creds["chat_secret"], nonce)
 
     pkt = bytes([0xD9, 0xA0, 0xA0])
@@ -377,7 +384,7 @@ def parse_override_state(payload: bytes) -> dict | None:
     Payload format:
         Byte 0:   high battery marker (percentage)
         Byte 1:   low battery marker (percentage)
-        Byte 2:   version / dirty flag
+        Byte 2:   battery-range override-enable flag (0 = AI, 1 = override)
         Byte 3:   ``0x58`` (subscription response tag)
         Bytes 4-7: extended header
         Byte 8:   slot count (``0x60``=96 or ``0xC0``=192)
@@ -390,7 +397,8 @@ def parse_override_state(payload: bytes) -> dict | None:
 
     Returns:
         Dict with ``slots`` (list of 96 or 192 ints), ``high_marker``,
-        and ``low_marker``; or *None* on invalid input.
+        ``low_marker``, and ``battery_range_override`` (bool); or *None*
+        on invalid input.
     """
     if payload is None or len(payload) < 105:
         return None
@@ -402,6 +410,7 @@ def parse_override_state(payload: bytes) -> dict | None:
     return {
         "high_marker": payload[0],
         "low_marker": payload[1],
+        "battery_range_override": payload[2] != 0,
         "slots": list(payload[9 : 9 + n_slots]),
     }
 
@@ -1023,13 +1032,16 @@ def send_override(
     *,
     high_marker: int = DEFAULT_MARKER_HIGH,
     low_marker: int = DEFAULT_MARKER_LOW,
+    battery_range_override: bool = False,
     timeout: float = 3.0,
     log: Callable[..., None] | None = None,
 ) -> bool:
     """Send override slot values via E2E protocol.
 
     Performs the full session flow and sends the override packet.
-    Returns *True* if the server acknowledged the override.
+    Returns *True* if the server acknowledged the override. Set
+    ``battery_range_override=True`` to also activate the app's
+    "Battery Range = override" mode (byte 2 of payload).
     """
     session_nonce = generate_nonce()
 
@@ -1048,6 +1060,7 @@ def send_override(
     override_pkt = build_override_packet(
         e2e_creds, slot_values, nonce=session_nonce,
         high_marker=high_marker, low_marker=low_marker,
+        battery_range_override=battery_range_override,
     )
 
     host, port = _resolve_host(e2e_creds["host"])

--- a/custom_components/emaldo/number.py
+++ b/custom_components/emaldo/number.py
@@ -24,10 +24,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EmaldoCoordinator
+from .schedule_coordinator import EmaldoScheduleCoordinator
 from .emaldo_lib.e2e import (
     EV_MODE_INSTANT_FIXED,
     set_ev_charging_mode_instant,
 )
+from .emaldo_lib.exceptions import EmaldoAuthError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,15 +40,26 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Emaldo number entities from a config entry."""
-    power_coordinator: EmaldoCoordinator = hass.data[DOMAIN][entry.entry_id]["power"]
+    data = hass.data[DOMAIN][entry.entry_id]
+    power_coordinator: EmaldoCoordinator = data["power"]
+    schedule_coordinator: EmaldoScheduleCoordinator = data["schedule"]
 
-    # Only add the EV slider if the device actually reports EV state.
+    entities: list[NumberEntity] = []
+
+    # EV "Fixed charge amount" slider — only if device reports EV state.
     ev = (power_coordinator.data or {}).get("ev")
     if ev is None:
         _LOGGER.debug("No EV state reported; skipping EV fixed charge number")
-        return
+    else:
+        entities.append(EmaldoEvFixedChargeNumber(power_coordinator))
 
-    async_add_entities([EmaldoEvFixedChargeNumber(power_coordinator)])
+    # AI Battery Range markers — always present; override write is destructive
+    # (clears all per-15-min slot overrides), so the slider always sets the
+    # battery_range_override flag to whatever the switch entity reads.
+    entities.append(EmaldoBatteryRangeMarker(schedule_coordinator, "smart"))
+    entities.append(EmaldoBatteryRangeMarker(schedule_coordinator, "emergency"))
+
+    async_add_entities(entities)
 
 
 class EmaldoEvFixedChargeNumber(CoordinatorEntity[EmaldoCoordinator], NumberEntity):
@@ -117,4 +130,100 @@ class EmaldoEvFixedChargeNumber(CoordinatorEntity[EmaldoCoordinator], NumberEnti
         if not ok:
             _LOGGER.warning("EV fixed charge write (%d kWh) was not acknowledged", kwh)
         # Refresh so the stored state is re-read from the device
+        await self.coordinator.async_request_refresh()
+
+
+class EmaldoBatteryRangeMarker(
+    CoordinatorEntity[EmaldoScheduleCoordinator], NumberEntity
+):
+    """Slider for one of the AI Battery Range markers (smart or emergency).
+
+    Reads from the schedule coordinator's last `get_overrides` snapshot.
+    Writes via :meth:`EmaldoClient.set_battery_range`, which sends opcode
+    0x1AA0 with all 96 per-slot overrides cleared to 0x80. The override-active
+    flag (byte 2) is preserved from the last read state — only the
+    `EmaldoBatteryRangeOverrideSwitch` entity changes that flag.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:battery-charging-medium"
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(
+        self,
+        coordinator: EmaldoScheduleCoordinator,
+        kind: str,
+    ) -> None:
+        """Initialize. ``kind`` is 'smart' or 'emergency'."""
+        super().__init__(coordinator)
+        if kind not in ("smart", "emergency"):
+            raise ValueError(f"kind must be 'smart' or 'emergency' (got {kind!r})")
+        self._kind = kind
+        nice = "Smart reserve" if kind == "smart" else "Emergency reserve"
+        self._attr_name = f"AI {nice}"
+        self._attr_unique_id = f"{coordinator.home_id}_battery_range_{kind}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link to the main Emaldo device."""
+        c = self.coordinator
+        return DeviceInfo(
+            identifiers={(DOMAIN, c.device_id or c.home_id)},
+            name=c.device_name or "Emaldo Battery",
+            manufacturer="Emaldo",
+            model=c.device_model,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current marker % from the last override read."""
+        ov = (self.coordinator.data or {}).get("overrides") or {}
+        key = "high_marker" if self._kind == "smart" else "low_marker"
+        val = ov.get(key)
+        return float(val) if val is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Write a new marker. Preserves the other marker + override flag."""
+        new_pct = int(round(value))
+        ov = (self.coordinator.data or {}).get("overrides") or {}
+        smart = ov.get("high_marker", 50)
+        emergency = ov.get("low_marker", 10)
+        enable = bool(ov.get("battery_range_override", False))
+        if self._kind == "smart":
+            smart = new_pct
+        else:
+            emergency = new_pct
+        if smart < emergency:
+            _LOGGER.warning(
+                "Refusing battery-range write: smart (%d) < emergency (%d)",
+                smart, emergency,
+            )
+            return
+
+        def _write() -> bool:
+            for attempt in range(2):
+                try:
+                    client = self.coordinator._ensure_client()  # noqa: SLF001
+                    return client.set_battery_range(
+                        self.coordinator.home_id,
+                        self.coordinator._device_id,  # noqa: SLF001
+                        self.coordinator._model,      # noqa: SLF001
+                        smart_pct=smart,
+                        emergency_pct=emergency,
+                        enable=enable,
+                    )
+                except EmaldoAuthError:
+                    if attempt == 0:
+                        self.coordinator._client = None  # noqa: SLF001
+                    else:
+                        raise
+            return False
+
+        ok = await self.hass.async_add_executor_job(_write)
+        if not ok:
+            _LOGGER.warning("Battery Range write was not acknowledged")
         await self.coordinator.async_request_refresh()

--- a/custom_components/emaldo/services.py
+++ b/custom_components/emaldo/services.py
@@ -44,6 +44,15 @@ SERVICE_RESET_TO_INTERNAL = "reset_to_internal"
 SERVICE_REFRESH_SCHEDULE = "refresh_schedule"
 SERVICE_SET_EV_SCHEDULE = "set_ev_schedule"
 SERVICE_BACKFILL_SOLAR = "backfill_solar"
+SERVICE_SET_BATTERY_RANGE = "set_battery_range"
+
+SCHEMA_SET_BATTERY_RANGE = vol.Schema(
+    {
+        vol.Required("smart_pct"): vol.All(int, vol.Range(min=0, max=100)),
+        vol.Required("emergency_pct"): vol.All(int, vol.Range(min=0, max=100)),
+        vol.Optional("enable", default=True): cv.boolean,
+    }
+)
 
 SCHEMA_SET_SLOT_RANGE = vol.Schema(
     {
@@ -565,6 +574,52 @@ async def async_handle_backfill_solar(
     _LOGGER.info("Backfill solar: done")
 
 
+async def async_handle_set_battery_range(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Handle the set_battery_range service call.
+
+    Writes the AI Battery Range — the SoC band the AI must operate within.
+    Mirrors the app's "Save Battery Range" save: clears all 96 per-15-min
+    slot overrides to 0x80 and sets byte 2 = 1 ("override mode active") when
+    ``enable`` is True.
+    """
+    smart = call.data["smart_pct"]
+    emergency = call.data["emergency_pct"]
+    enable = call.data.get("enable", True)
+    if smart < emergency:
+        raise vol.Invalid("smart_pct must be >= emergency_pct")
+
+    def _do_write():
+        for attempt in range(2):
+            try:
+                coord, client = _get_coordinator_and_client(hass)
+                hid, did, model = coord.home_id, coord._device_id, coord._model
+                ok = client.set_battery_range(
+                    hid, did, model,
+                    smart_pct=smart, emergency_pct=emergency, enable=enable,
+                )
+                if ok:
+                    _LOGGER.info(
+                        "Battery Range set: %d-%d%% (override=%s)",
+                        emergency, smart, enable,
+                    )
+                return ok
+            except EmaldoAuthError:
+                if attempt == 0:
+                    _LOGGER.debug("Session expired, re-authenticating")
+                    coord._client = None
+                else:
+                    raise
+
+    await hass.async_add_executor_job(_do_write)
+
+    entries = hass.data.get(DOMAIN, {})
+    for entry_data in entries.values():
+        coord = entry_data["schedule"]
+        await coord.async_request_refresh()
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register Emaldo services."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_SLOT_RANGE):
@@ -587,6 +642,9 @@ def async_register_services(hass: HomeAssistant) -> None:
 
     async def handle_backfill_solar(call: ServiceCall) -> None:
         await async_handle_backfill_solar(hass, call)
+
+    async def handle_set_battery_range(call: ServiceCall) -> None:
+        await async_handle_set_battery_range(hass, call)
 
     hass.services.async_register(
         DOMAIN,
@@ -623,6 +681,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         handle_backfill_solar,
         schema=SCHEMA_BACKFILL_SOLAR,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_BATTERY_RANGE,
+        handle_set_battery_range,
+        schema=SCHEMA_SET_BATTERY_RANGE,
+    )
 
 
 def async_unregister_services(hass: HomeAssistant) -> None:
@@ -634,3 +698,4 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         hass.services.async_remove(DOMAIN, SERVICE_REFRESH_SCHEDULE)
         hass.services.async_remove(DOMAIN, SERVICE_SET_EV_SCHEDULE)
         hass.services.async_remove(DOMAIN, SERVICE_BACKFILL_SOLAR)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_BATTERY_RANGE)

--- a/custom_components/emaldo/services.yaml
+++ b/custom_components/emaldo/services.yaml
@@ -169,3 +169,46 @@ backfill_solar:
           min: 1
           max: 90
           step: 1
+
+set_battery_range:
+  name: Set AI Battery Range
+  description: >
+    Write the AI Battery Range — the SoC band the AI must operate within.
+    Mirrors the app's Battery Range slider + override toggle. Sends opcode
+    0x1AA0 with all 96 per-15-min slot overrides cleared to 0x80
+    (no-override). Live-confirmed 2026-05-07 against Power Core 2.0.
+  fields:
+    smart_pct:
+      name: Smart reserve %
+      description: Upper SoC threshold of the AI operating band (0-100).
+      required: true
+      example: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    emergency_pct:
+      name: Emergency reserve %
+      description: >
+        Lower SoC threshold of the AI operating band (0-100). Must be
+        less than or equal to smart_pct.
+      required: true
+      example: 10
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+    enable:
+      name: Override active
+      description: >
+        True (default) activates "Battery Range = override" — AI is constrained
+        to [emergency_pct, smart_pct]. False reverts to "Battery Range = AI" —
+        the markers are persisted but AI picks its own band.
+      default: true
+      example: true
+      selector:
+        boolean:

--- a/custom_components/emaldo/switch.py
+++ b/custom_components/emaldo/switch.py
@@ -1,0 +1,114 @@
+"""Switch platform for Emaldo integration.
+
+Exposes the AI Battery Range "override active" toggle as a ``switch``
+entity. When ON, the AI is constrained to operate inside
+``[emergency_pct, smart_pct]`` (the values surfaced by the
+``EmaldoBatteryRangeMarker`` ``number`` entities). When OFF, AI picks
+its own band.
+
+Writes go via :meth:`EmaldoClient.set_battery_range`, which sends opcode
+0x1AA0 with all 96 per-slot overrides cleared to 0x80 — same wire write as
+the app's "Save Battery Range" button.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .schedule_coordinator import EmaldoScheduleCoordinator
+from .emaldo_lib.exceptions import EmaldoAuthError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Emaldo switch entities from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    schedule_coordinator: EmaldoScheduleCoordinator = data["schedule"]
+    async_add_entities([EmaldoBatteryRangeOverrideSwitch(schedule_coordinator)])
+
+
+class EmaldoBatteryRangeOverrideSwitch(
+    CoordinatorEntity[EmaldoScheduleCoordinator], SwitchEntity
+):
+    """ON = AI must operate inside [emergency, smart]; OFF = AI picks the band."""
+
+    _attr_has_entity_name = True
+    _attr_name = "AI Battery Range override"
+    _attr_icon = "mdi:battery-lock"
+
+    def __init__(self, coordinator: EmaldoScheduleCoordinator) -> None:
+        """Initialize the override switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.home_id}_battery_range_override"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link to the main Emaldo device."""
+        c = self.coordinator
+        return DeviceInfo(
+            identifiers={(DOMAIN, c.device_id or c.home_id)},
+            name=c.device_name or "Emaldo Battery",
+            manufacturer="Emaldo",
+            model=c.device_model,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether override mode is active per the last read."""
+        ov = (self.coordinator.data or {}).get("overrides") or {}
+        val = ov.get("battery_range_override")
+        return bool(val) if val is not None else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate override mode using the currently-stored markers."""
+        await self._write(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Revert to AI-chosen Battery Range; markers are persisted."""
+        await self._write(False)
+
+    async def _write(self, enable: bool) -> None:
+        ov = (self.coordinator.data or {}).get("overrides") or {}
+        smart = ov.get("high_marker", 50)
+        emergency = ov.get("low_marker", 10)
+
+        def _do_write() -> bool:
+            for attempt in range(2):
+                try:
+                    client = self.coordinator._ensure_client()  # noqa: SLF001
+                    return client.set_battery_range(
+                        self.coordinator.home_id,
+                        self.coordinator._device_id,  # noqa: SLF001
+                        self.coordinator._model,      # noqa: SLF001
+                        smart_pct=smart,
+                        emergency_pct=emergency,
+                        enable=enable,
+                    )
+                except EmaldoAuthError:
+                    if attempt == 0:
+                        self.coordinator._client = None  # noqa: SLF001
+                    else:
+                        raise
+            return False
+
+        ok = await self.hass.async_add_executor_job(_do_write)
+        if not ok:
+            _LOGGER.warning(
+                "Battery Range override toggle was not acknowledged (target=%s)",
+                enable,
+            )
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

Adds Home Assistant entities and a service for the device's **AI Battery Range** setting — the SoC band the AI must operate within. This is the same setting exposed in the official Emaldo app under "Battery Range" (AI vs override).

- `number.emaldo_ai_smart_reserve` — slider for the upper SoC %
- `number.emaldo_ai_emergency_reserve` — slider for the lower SoC %
- `switch.emaldo_ai_battery_range_override` — ON activates "override" mode (the app's Battery Range toggle), OFF reverts to AI-chosen band
- `emaldo.set_battery_range` service for scripts/automations

## Wire-protocol change

Opcode `0x1AA0` (the override write the integration already uses) has an enable flag in `payload[2]` that we were always sending as `0x00`. Setting it to `0x01` — which is what the Android app's `BmtCmd.SET_RESERVE_MODE_AI` does — flips Battery Range to override mode on the device.

Plumbed through:
- `build_override_packet(..., battery_range_override=False)`
- `send_override(..., battery_range_override=False)`
- `EmaldoClient.set_override` / `reset_overrides` (new kwarg)
- `EmaldoClient.set_battery_range(home_id, device_id, model, *, smart_pct, emergency_pct, enable)` — convenience helper that mirrors the app's "Save Battery Range" button (sets the markers + clears all 96 per-15-min slots to `0x80`)
- `parse_override_state` reads the byte back so entities show live state

## Live-tested

Verified end-to-end against a `PC1-BAK15-HS10` (Power Core 2.0):
1. Writing `smart=50, emergency=10, enable=1` round-trips and the device's `GetOverrides` returns the new markers + override-active flag.
2. The Emaldo Android app shows the new range after force-close + relaunch (it caches its own copy on screen entry).
3. The new HA entities reflect live device state and write back through the same path.

## Notes for reviewers

- Service-call writes use the same `EmaldoAuthError` retry pattern as the existing `services.py` handlers (one `coord._client = None` retry on stale token).
- `number`/`switch` writes preserve the *other* values from the last read — e.g. dragging the smart slider keeps the override flag and the emergency value as-is.
- Caveat: every Battery-Range write clears all 96 per-15-min slot overrides to `0x80`. This matches the official app's Save behaviour but is worth noting if downstream automations rely on slot-level overrides.

## Test plan

- [ ] Restart HA after deploying — confirm three new entities appear under your Emaldo device
- [ ] Drag `number.emaldo_ai_smart_reserve` and verify the device picks up the new value (re-read via `homeassistant.update_entity`)
- [ ] Toggle `switch.emaldo_ai_battery_range_override` and confirm Battery Range mode switches in the Emaldo app (force-close + relaunch app to refresh its cache)
- [ ] Call `emaldo.set_battery_range` from Developer Tools → Services with `smart_pct`, `emergency_pct`, `enable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)