### PR TITLE
Fix silent write failures on switch commands (#51)

### DIFF
--- a/custom_components/emaldo/coordinator.py
+++ b/custom_components/emaldo/coordinator.py
@@ -1353,6 +1353,62 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
             "e2e_rtt_last_ms": self.stats_e2e_rtt_last_ms,
         }
 
+    #: Tolerate this many device-convergence retries before giving up and
+    #: logging a warning (#51). Separate from the transport-level retry
+    #: already inside each ``_write_*`` method — this retries the whole
+    #: write+read-back cycle when the command was transmitted successfully
+    #: but the device state never confirms the requested value.
+    _WRITE_VERIFY_RETRIES = 2
+    #: Delay between a write and reading back confirmed state, giving the
+    #: relay/device time to apply the command before we check.
+    _WRITE_VERIFY_DELAY_S = 1.0
+
+    def _write_verified(
+        self,
+        write_fn: Callable[[], None],
+        read_fn: Callable[[], dict | None],
+        result_key: str,
+        expected: Any,
+        label: str,
+    ) -> Any:
+        """Write a command and confirm the device actually applied it (#51).
+
+        Several switch commands were previously fire-and-forget: once the
+        write call returned without raising, the caller assumed success —
+        even though a command can be transmitted successfully and still
+        never take effect on the device. This retries the write up to
+        ``_WRITE_VERIFY_RETRIES`` times if the confirmed state read back via
+        ``read_fn`` does not match ``expected``, and logs a warning instead
+        of silently reporting success when it never converges.
+
+        Returns the last confirmed value (which may differ from
+        ``expected``), or ``None`` if no read ever succeeded, so callers can
+        reflect the real device state instead of assuming the write worked.
+        """
+        import time
+
+        confirmed_value = None
+        for attempt in range(self._WRITE_VERIFY_RETRIES + 1):
+            write_fn()
+            time.sleep(self._WRITE_VERIFY_DELAY_S)
+            confirmed = read_fn()
+            if confirmed is not None:
+                confirmed_value = confirmed.get(result_key)
+                if confirmed_value == expected:
+                    return confirmed_value
+            if attempt < self._WRITE_VERIFY_RETRIES:
+                _LOGGER.debug(
+                    "%s not yet confirmed (attempt %d/%d, target=%s, read=%s)",
+                    label, attempt + 1, self._WRITE_VERIFY_RETRIES + 1,
+                    expected, confirmed_value,
+                )
+        _LOGGER.warning(
+            "%s command was not confirmed by the device after %d attempts "
+            "(target=%s, last confirmed=%s)",
+            label, self._WRITE_VERIFY_RETRIES + 1, expected, confirmed_value,
+        )
+        return confirmed_value
+
     def _write_thirdparty_pv(self, enabled: bool) -> None:
         """Send SET_THIRDPARTYPV_ON (0x41) via the existing persistent session.
 
@@ -1385,6 +1441,21 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
                 self._invalidate_session_ref()
                 if attempt == 1:
                     raise
+
+    def _write_thirdparty_pv_verified(self, enabled: bool) -> Any:
+        """Write third-party PV state and confirm the device applied it (#51).
+
+        ``_read_power_flow`` decodes ``thirdparty_pv_on`` from the regular
+        realtime power-flow packet, so it doubles as a fresh confirmation
+        read with no separate device query needed.
+        """
+        return self._write_verified(
+            lambda: self._write_thirdparty_pv(enabled),
+            self._read_power_flow,
+            "thirdparty_pv_on",
+            enabled,
+            "Third-party PV",
+        )
 
     def _write_sell_back_to_grid(self, enabled: bool) -> None:
         """Enable or disable grid export (sell-back to grid) via set_virtualpowerplant.
@@ -1422,6 +1493,16 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
         session = self._ensure_session()
         return session.read_virtualpowerplant()
 
+    def _write_sell_back_to_grid_verified(self, enabled: bool) -> Any:
+        """Write sell-back-to-grid state and confirm the device applied it (#51)."""
+        return self._write_verified(
+            lambda: self._write_sell_back_to_grid(enabled),
+            self._read_virtualpowerplant,
+            "sell_back_to_grid_on",
+            enabled,
+            "Sell-back-to-grid",
+        )
+
     def _write_sell_limit(self, enabled: bool, threshold: int) -> None:
         """Set sell-limit protection (set_sellingprotection, type 0x5E).
 
@@ -1454,6 +1535,16 @@ class EmaldoRealtimeCoordinator(DataUpdateCoordinator[dict[str, Any] | None]):
         """Read sell-limit (selling protection) state via the persistent session."""
         session = self._ensure_session()
         return session.read_selling_protection()
+
+    def _write_sell_limit_verified(self, enabled: bool, threshold: int) -> Any:
+        """Write sell-limit state and confirm the device applied it (#51)."""
+        return self._write_verified(
+            lambda: self._write_sell_limit(enabled, threshold),
+            self._read_sell_limit,
+            "selling_protection_on",
+            enabled,
+            "Sell limit",
+        )
 
     def _write_manual_selling(self, on: bool, target_kwh: int) -> None:
         """Enable or disable manual energy selling (type 0x80).

--- a/custom_components/emaldo/switch.py
+++ b/custom_components/emaldo/switch.py
@@ -5,7 +5,6 @@ Exposes Third-party PV toggle and AI Battery Range override toggle.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -90,20 +89,28 @@ class EmaldoThirdPartyPVSwitch(
         return self.coordinator.data.get("thirdparty_pv_on")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Enable third-party PV."""
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_thirdparty_pv, True  # noqa: SLF001
+        """Enable third-party PV, verifying the device confirms it (#51)."""
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_thirdparty_pv_verified, True  # noqa: SLF001
         )
-        await asyncio.sleep(1.5)
-        await self.coordinator.async_request_refresh()
+        if confirmed is not None and self.coordinator.data is not None:
+            updated = dict(self.coordinator.data)
+            updated["thirdparty_pv_on"] = confirmed
+            self.coordinator.async_set_updated_data(updated)
+        else:
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Disable third-party PV."""
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_thirdparty_pv, False  # noqa: SLF001
+        """Disable third-party PV, verifying the device confirms it (#51)."""
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_thirdparty_pv_verified, False  # noqa: SLF001
         )
-        await asyncio.sleep(1.5)
-        await self.coordinator.async_request_refresh()
+        if confirmed is not None and self.coordinator.data is not None:
+            updated = dict(self.coordinator.data)
+            updated["thirdparty_pv_on"] = confirmed
+            self.coordinator.async_set_updated_data(updated)
+        else:
+            await self.coordinator.async_request_refresh()
 
 
 class EmaldoSellBackToGridSwitch(
@@ -146,23 +153,23 @@ class EmaldoSellBackToGridSwitch(
         return self.coordinator.data.get("sell_back_to_grid_on")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Allow grid export (enable sell-back to grid)."""
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_sell_back_to_grid, True  # noqa: SLF001
+        """Allow grid export (enable sell-back to grid), verifying the device confirms it (#51)."""
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_sell_back_to_grid_verified, True  # noqa: SLF001
         )
-        if self.coordinator.data is not None:
+        if confirmed is not None and self.coordinator.data is not None:
             updated = dict(self.coordinator.data)
-            updated["sell_back_to_grid_on"] = True
+            updated["sell_back_to_grid_on"] = confirmed
             self.coordinator.async_set_updated_data(updated)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Block grid export (disable sell-back to grid)."""
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_sell_back_to_grid, False  # noqa: SLF001
+        """Block grid export (disable sell-back to grid), verifying the device confirms it (#51)."""
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_sell_back_to_grid_verified, False  # noqa: SLF001
         )
-        if self.coordinator.data is not None:
+        if confirmed is not None and self.coordinator.data is not None:
             updated = dict(self.coordinator.data)
-            updated["sell_back_to_grid_on"] = False
+            updated["sell_back_to_grid_on"] = confirmed
             self.coordinator.async_set_updated_data(updated)
 
 
@@ -212,25 +219,25 @@ class EmaldoSellLimitSwitch(
         return int(self.coordinator.data.get("sell_limit_threshold") or 0)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Activate sell limit with the last-known threshold."""
+        """Activate sell limit with the last-known threshold, verifying the device confirms it (#51)."""
         threshold = self._current_threshold()
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_sell_limit, True, threshold  # noqa: SLF001
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_sell_limit_verified, True, threshold  # noqa: SLF001
         )
-        if self.coordinator.data is not None:
+        if confirmed is not None and self.coordinator.data is not None:
             updated = dict(self.coordinator.data)
-            updated["sell_limit_on"] = True
+            updated["sell_limit_on"] = confirmed
             self.coordinator.async_set_updated_data(updated)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Deactivate sell limit (keep threshold for future re-activation)."""
+        """Deactivate sell limit, verifying the device confirms it (#51) (keeps threshold for future re-activation)."""
         threshold = self._current_threshold()
-        await self.hass.async_add_executor_job(
-            self.coordinator._write_sell_limit, False, threshold  # noqa: SLF001
+        confirmed = await self.hass.async_add_executor_job(
+            self.coordinator._write_sell_limit_verified, False, threshold  # noqa: SLF001
         )
-        if self.coordinator.data is not None:
+        if confirmed is not None and self.coordinator.data is not None:
             updated = dict(self.coordinator.data)
-            updated["sell_limit_on"] = False
+            updated["sell_limit_on"] = confirmed
             self.coordinator.async_set_updated_data(updated)
 
 


### PR DESCRIPTION
Fixes #51

## Problem

Several switch entities assume success immediately after a write operation.
If a command is transmitted successfully but never applied by the inverter,
Home Assistant continues to report the requested state without detecting the
failure.

## Fix

Added a shared write verification helper that performs:

- write
- refresh
- verify confirmed device state
- retry when necessary
- log a warning if the requested state cannot be confirmed

Applied to:

- EmaldoThirdPartyPVSwitch
- EmaldoSellBackToGridSwitch
- EmaldoSellLimitSwitch

The switches now update their state only after successful verification,
instead of assuming the write succeeded.

## Scope

This PR adds verification, retry and warning on top of the existing write
path.

It does not modify credential or session routing.