### PR TITLE
feat: scheduled mode support (emaldo.set_scheduled_mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,58 @@ data:
   enable: true
 ```
 
+### `emaldo.set_scheduled_mode`
+
+Switches the battery to **Scheduled mode** and writes the hourly schedule (E2E opcode `0x19`).
+
+A scheduled-mode hour carries a *target percentage*, not an on/off flag, so each hour takes one
+of six actions: `neither`, `charge_to_emergency`, `charge_to_smart`, `charge_to_full`,
+`discharge_to_smart`, `discharge_to_emergency`. An integer works too — positive charges up to
+N%, negative discharges down to N%. Hours left out are `neither`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `weekday_hours` | dict[int, str\|int] | no | `{hour: action}` for Mon–Fri |
+| `weekend_hours` | dict[int, str\|int] | no | `{hour: action}` for Sat–Sun; only takes effect when `sync: false` |
+| `sync` | boolean | no | Default `true`. On: the battery discards `weekend_hours` and applies the weekday schedule all week |
+| `smart_pct` | int | no | Upper SoC threshold (0–100). Omit to keep the battery's current value |
+| `emergency_pct` | int | no | Lower SoC threshold (0–100). Omit to keep the battery's current value |
+| `device_id` | string | no | Target a specific device; defaults to the first |
+| `weekdays` | list[int] | no | *Deprecated.* Hours to charge, all to `charge_pct` |
+| `weekend` | list[int] | no | *Deprecated.* As `weekdays` |
+| `charge_pct` | int | no | *Deprecated.* Charge target for the hour lists (default 100) |
+
+The named actions resolve against the battery range **being written in the same call**, so
+changing `smart_pct` and using `charge_to_smart` together encodes against the new value.
+
+`smart_pct`/`emergency_pct` cannot be skipped on the wire — opcode `0x19` carries them in bytes
+2–3 on every write — so omitting them makes the service read the current range from `0x5B` and
+send it back unchanged.
+
+```yaml
+# Charge overnight, discharge through the evening peak
+service: emaldo.set_scheduled_mode
+data:
+  weekday_hours:
+    0: charge_to_full
+    1: charge_to_full
+    2: charge_to_full
+    17: discharge_to_emergency
+    18: discharge_to_emergency
+  sync: true
+```
+
+```yaml
+# Different weekend plan, with an explicit range
+service: emaldo.set_scheduled_mode
+data:
+  weekday_hours: { 3: charge_to_smart, 18: discharge_to_emergency }
+  weekend_hours: { 10: charge_to_full, 20: discharge_to_smart }
+  smart_pct: 80
+  emergency_pct: 20
+  sync: false
+```
+
 ## Slot Encoding
 
 The Emaldo battery uses single-byte override values per 15-minute slot:

--- a/custom_components/emaldo/emaldo_lib/client.py
+++ b/custom_components/emaldo/emaldo_lib/client.py
@@ -1559,3 +1559,55 @@ class EmaldoClient:
         """
         creds = self.e2e_login(home_id, device_id, model)
         return _e2e.get_manual_selling(creds, log=log)
+
+    # ── Scheduled mode (reserve mode) ────────────────────────────────
+
+    def get_schedule_mode(
+        self,
+        home_id: str,
+        device_id: str,
+        model: str,
+        *,
+        log: Callable[..., None] | None = None,
+    ) -> dict | None:
+        """Read the scheduled mode configuration via E2E (opcode 0x18).
+
+        Returns a dict with ``smart``, ``emergency``, ``weekday_slots``,
+        ``weekend_slots``, ``sync``, ``full_charge``, ``enable``; or *None*.
+        """
+        creds = self.e2e_login(home_id, device_id, model)
+        return _e2e.read_schedule_mode(creds, log=log)
+
+    def set_reserve_mode(
+        self,
+        home_id: str,
+        device_id: str,
+        model: str,
+        reserve_mode: int,
+        weekday_slots: list[int] | None = None,
+        weekend_slots: list[int] | None = None,
+        *,
+        smart_pct: int,
+        emergency_pct: int,
+        sync: bool = False,
+        enable: int = 0,
+        log: Callable[..., None] | None = None,
+    ) -> bool:
+        """Set the battery reserve mode via E2E (opcode 0x19).
+
+        Args:
+            reserve_mode: 1=priceTracking, 2=scheduled, 3=aiAdapter.
+            weekday_slots: 24 wire values for Mon–Fri. An hour carries a target
+                percentage, not a flag — see ``e2e.encode_slot``.
+            weekend_slots: 24 wire values for Sat–Sun.
+            smart_pct: Smart battery % (high marker). Required, with no default:
+                opcode 0x19 carries it on every write, so a default would
+                overwrite the battery's current range.
+            emergency_pct: Emergency battery % (low marker). As *smart_pct*.
+        """
+        creds = self.e2e_login(home_id, device_id, model)
+        return _e2e.set_reserve_mode(
+            creds, reserve_mode, weekday_slots, weekend_slots,
+            smart_pct=smart_pct, emergency_pct=emergency_pct,
+            sync=sync, enable=enable, log=log,
+        )

--- a/custom_components/emaldo/emaldo_lib/e2e.py
+++ b/custom_components/emaldo/emaldo_lib/e2e.py
@@ -5516,3 +5516,577 @@ class PersistentE2ESession:
                 if not has_more:
                     break
         return False
+
+
+# ---------------------------------------------------------------------------
+# Scheduled mode (reserve mode) — E2E set/get
+# ---------------------------------------------------------------------------
+#
+# Write — ``set_reservemode``, APK dispatch-table case 43 ('+').
+# Opcode 0x19 (short -24551 = 0xA019), subscribe mode, 54-byte payload.
+_RESERVE_MODE_SET_TYPE = 0x19
+
+# Read — ``get_schedule_reservemode``, the scheduled-mode hourly schedule.
+# Opcode 0x18, subscribe mode, empty payload, 57-byte response.
+#
+# Layout, per the APK callback (``module_bmt/zd/q0.java``) and confirmed against a
+# live battery: [0] smart, [1] emergency, [2] lowpower alert, [3] battery protect,
+# [4..27] weekday hours, [28..51] weekend hours, [52] sync, [53..56] full charge.
+#
+# Not to be confused with ``get_custom_schedulemode`` (opcode 0x46), a separate
+# block that reads back 0x80 (unset) for every hour regardless of the app's
+# setting, and whose bytes 0-1 are a fixed header rather than the battery range.
+_SCHEDULE_MODE_GET_TYPE = 0x18
+
+RESERVE_MODE_PRICE_TRACKING = 1
+RESERVE_MODE_SCHEDULED = 2
+RESERVE_MODE_AI_ADAPTER = 3
+
+
+def set_reserve_mode(
+    e2e_creds: dict,
+    reserve_mode: int,
+    weekday_slots: list[int] | None = None,
+    weekend_slots: list[int] | None = None,
+    *,
+    smart_pct: int,
+    emergency_pct: int,
+    sync: bool = False,
+    enable: int = 0,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> bool:
+    """Set the battery reserve mode via E2E (opcode 0x19).
+
+    Args:
+        reserve_mode: 1=priceTracking, 2=scheduled, 3=aiAdapter.
+        weekday_slots: 24 wire values, one per hour, for Mon–Fri. An hour carries
+            a *target percentage*, not an on/off flag — see :func:`encode_slot`.
+            Required when *reserve_mode* is ``RESERVE_MODE_SCHEDULED``.
+        weekend_slots: 24 wire values for Sat–Sun. Same encoding.
+        smart_pct: Smart battery percentage (high marker). Required, with no
+            default: bytes 2-3 carry it on *every* write, so a default here would
+            silently overwrite whatever range the battery is set to. Read the
+            current value with :func:`read_reserve_mode_config` and pass it back
+            when the caller does not mean to change it.
+        emergency_pct: Emergency battery percentage (low marker). As *smart_pct*.
+        sync: Synchronise weekday/weekend schedules.
+        enable: Enable flag (int, sent as byte 53).
+
+    Returns:
+        *True* if the device acknowledged the command.
+    """
+    assert reserve_mode in (1, 2, 3), f"Invalid reserve_mode: {reserve_mode}"
+
+    payload = bytearray(54)
+    payload[0] = reserve_mode - 1
+
+    has_slots = (
+        weekday_slots is not None
+        and weekend_slots is not None
+        and (len(weekday_slots) > 0 or len(weekend_slots) > 0)
+    )
+    if reserve_mode == RESERVE_MODE_SCHEDULED and not has_slots:
+        payload[1] = 1
+    else:
+        payload[1] = 0
+
+    payload[2] = smart_pct & 0xFF
+    payload[3] = emergency_pct & 0xFF
+
+    if has_slots:
+        for i, v in enumerate(weekday_slots[:24]):
+            payload[4 + i] = v & 0xFF
+        for i, v in enumerate(weekend_slots[:24]):
+            payload[28 + i] = v & 0xFF
+
+    payload[52] = 1 if sync else 0
+    payload[53] = enable & 0xFF
+
+    session_nonce = generate_nonce()
+    pkt = build_subscription_packet(
+        e2e_creds, _RESERVE_MODE_SET_TYPE, session_nonce,
+        payload=bytes(payload),
+    )
+    results = _run_session(
+        e2e_creds, [("SetReserveMode(0x19)", pkt)],
+        timeout=timeout, log=log,
+    )
+    _, resp = results[0]
+    return resp is not None
+
+
+def _parse_schedule_mode_response(payload: bytes) -> dict | None:
+    """Parse a get_schedule_reservemode (0x18) response payload."""
+    if payload is None or len(payload) < 57:
+        return None
+    return {
+        "smart": payload[0],
+        "emergency": payload[1],
+        "lowpower_alert": payload[2],
+        "battery_protect": payload[3],
+        "weekday_slots": list(payload[4:28]),
+        "weekend_slots": list(payload[28:52]),
+        "sync": payload[52] == 1,
+        "full_charge": int.from_bytes(payload[53:57], "little"),
+        "enable": payload[57] if len(payload) > 57 else 0,
+    }
+
+
+# Upper bound on distinct hour values in a genuine schedule.
+_MAX_DISTINCT_SLOT_VALUES = 6
+
+
+def _is_plausible_slot_value(b: int) -> bool:
+    """A slot value the device could legitimately report.
+
+    Override slot encoding: 0x00 idle, 1-100 charge below N%, 0x80 no setting,
+    129-255 discharge above (256-N)%. 101-127 is not a valid value.
+    """
+    return b in (0x00, 0x80) or 1 <= b <= 100 or b >= 129
+
+
+def _is_schedule_mode_payload(payload: bytes) -> bool:
+    """Identify a real get_schedule_reservemode (0x18) payload.
+
+    This does more work than it looks like it should, because
+    :func:`decrypt_response` brute-forces the AES IV and every 16-aligned tail
+    offset and returns the FIRST candidate this accepts. So the check is not a
+    sanity assertion — it is what selects the correct decryption. Wrong-offset
+    garbage unpads cleanly often enough that a loose check will pick it and parse
+    it as an empty schedule with nonsense thresholds.
+
+    Every constraint below therefore comes from the documented layout, to leave
+    random plaintext as little room to qualify as possible.
+    """
+    # Exact lengths, not ">= 57". The offset search yields nested candidates that are
+    # all suffixes of each other - 57, 74, 90, 106 bytes and so on - and a longer one
+    # whose first 57 bytes happen to satisfy the shape checks would be accepted and
+    # parsed as real. 0x18 returns 57 bytes, 0x46 returns 58.
+    if payload is None or len(payload) not in (57, 58):
+        return False
+    if payload[0] > 100 or payload[1] > 100:      # smart, emergency
+        return False
+    if payload[2] > 100 or payload[3] > 100:      # lowpower alert, battery protect
+        return False
+    # Hour values. The device uses the same encoding as the override block, not the
+    # plain 0/1 the APK writes: 0x00 idle, 1-100 charge below N%, 0x80 for an hour
+    # with no setting, 129-255 discharge above (256-N)%. 101-127 is unused.
+    slots = payload[4:52]
+    if any(not _is_plausible_slot_value(b) for b in slots):
+        return False
+    # A real schedule draws from a handful of values (unset, idle, one charge
+    # target, one discharge target); random plaintext spreads across many. This
+    # carries most of the discriminating power now that the per-byte range is wide.
+    if len(set(slots)) > _MAX_DISTINCT_SLOT_VALUES:
+        return False
+    if payload[52] > 1:                           # sync boolean
+        return False
+    # The APK checks length >= 57 but then reads byte 57, so a real payload has it;
+    # when present it is a flag.
+    if len(payload) > 57 and payload[57] > 1:     # enable flag
+        return False
+    # A device always has non-zero thresholds with the upper above the lower.
+    # Without these two a run of zero bytes satisfies everything above.
+    if payload[0] == 0 and payload[1] == 0:
+        return False
+    if payload[0] <= payload[1]:
+        return False
+    return True
+
+
+def read_schedule_mode(
+    e2e_creds: dict,
+    *,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read the current scheduled mode configuration via E2E (opcode 0x18).
+
+    Returns a dict with ``smart``, ``emergency``, ``weekday_slots`` (24 ints),
+    ``weekend_slots`` (24 ints), ``sync``, ``full_charge``, ``enable``;
+    or *None* on failure.
+
+    Structured like :func:`read_overrides` rather than going through
+    ``_run_session``: the first datagram back after a subscribe is often a relay
+    or keepalive frame, so the socket is drained until one validates as a
+    schedule-mode response rather than taking whatever arrives first.
+    """
+    session_nonce = generate_nonce()
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
+    sub_pkt = build_subscription_packet(
+        e2e_creds, _SCHEDULE_MODE_GET_TYPE, session_nonce,
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B -> got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if log:
+                log(f"{label}: timeout")
+            return None
+
+    def _try(resp: bytes | None, label: str) -> dict | None:
+        if not resp:
+            return None
+        decrypted = decrypt_response(
+            resp, e2e_creds["chat_secret"],
+            payload_validator=_is_schedule_mode_payload,
+            # Benign relay frames are not schedule-mode payloads; silence the
+            # per-call decrypt failure flood.
+            silent=True,
+        )
+        if log:
+            log(f"0x18 {label}: " + (
+                f"{len(decrypted)}B = {decrypted.hex()}" if decrypted
+                else "did not decrypt / failed validation"))
+        return _parse_schedule_mode_response(decrypted)
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+
+        result = _try(_send(sub_pkt, "Subscribe(0x18)"), "subscribe response")
+        if result is not None:
+            return result
+
+        # The first response may not be the right type; try a few more.
+        for i in range(5):
+            try:
+                resp, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            result = _try(resp, f"drained frame {i + 1}")
+            if result is not None:
+                return result
+
+        if log:
+            log("read_schedule_mode: no frame validated as a schedule-mode response")
+        return None
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# Reserve mode configuration - opcode 0x5B
+# ---------------------------------------------------------------------------
+#
+# Named "peak shaving config" above, but the 20-byte response actually carries
+# the reserve-mode configuration. Layout established by observation against a
+# real battery rather than from the APK: the range was changed in the app and
+# bytes 15 and 17 followed it exactly, twice (63/25 → 55/30 → 25/10), in plain
+# binary.
+#
+#   [0..6]   always zero so far
+#   [7..10]  full charge capacity, Wh, uint32 LE
+#   [11..14] uint32 LE, static, meaning unknown (NOT current energy - it stayed
+#            at 7128 while SoC was 54% of 15288)
+#   [15]     emergency (lower) reserve %
+#   [16]     always 100 so far, meaning unknown (not plenty_reserve, which is 98)
+#   [17]     smart (upper) reserve %
+#   [18]     reserve mode: 1 price tracking, 2 scheduled, 3 AI adapter
+#   [19]     enabled flag
+#
+# This is the only read that reports the current reserve mode. For the battery
+# range it agrees with 0x18, so the two can be cross-checked; 0x46 cannot be used
+# for either — its first two bytes read 0x50 0x0F regardless of the app's setting,
+# because they are a fixed header rather than smart/emergency.
+
+_RESERVE_CONFIG_GET_TYPE = 0x5B
+_RESERVE_CONFIG_LENGTH = 20
+
+
+def _is_reserve_config_payload(payload: bytes) -> bool:
+    """Identify a 0x5B reserve-config payload.
+
+    As with the schedule-mode read, this selects the AES offset rather than
+    merely sanity-checking, so it constrains every field the layout pins down.
+    """
+    if payload is None or len(payload) != _RESERVE_CONFIG_LENGTH:
+        return False
+    if payload[15] > 100 or payload[16] > 100 or payload[17] > 100:
+        return False
+    if payload[18] not in (RESERVE_MODE_PRICE_TRACKING,
+                           RESERVE_MODE_SCHEDULED,
+                           RESERVE_MODE_AI_ADAPTER):
+        return False
+    if payload[19] > 1:
+        return False
+    # Upper reserve sits above the lower one, and a real device is never 0/0.
+    if payload[17] <= payload[15]:
+        return False
+    return True
+
+
+def _parse_reserve_config(payload: bytes | None) -> dict | None:
+    """Parse a 0x5B reserve-config response."""
+    if payload is None or len(payload) != _RESERVE_CONFIG_LENGTH:
+        return None
+    return {
+        "full_charge_wh": int.from_bytes(payload[7:11], "little"),
+        "unknown_11": int.from_bytes(payload[11:15], "little"),
+        "emergency": payload[15],
+        "unknown_16": payload[16],
+        "smart": payload[17],
+        "reserve_mode": payload[18],
+        "enabled": payload[19] == 1,
+    }
+
+
+def read_reserve_mode_config(
+    e2e_creds: dict,
+    *,
+    timeout: float = 3.0,
+    log: Callable[..., None] | None = None,
+) -> dict | None:
+    """Read the reserve-mode configuration via E2E (opcode 0x5B).
+
+    Returns a dict with ``smart``, ``emergency``, ``reserve_mode``, ``enabled``
+    and ``full_charge_wh``; or *None* on failure.
+
+    :func:`read_schedule_mode` (0x18) also reports the battery range, and the two
+    can be cross-checked against each other. This is the only read that reports
+    which reserve mode the battery is currently in.
+    """
+    session_nonce = generate_nonce()
+    home_alive = build_alive_packet(
+        sender_end_id=e2e_creds["home_end_id"],
+        sender_group_id=e2e_creds["home_group_id"],
+        end_secret=e2e_creds["home_end_secret"],
+    )
+    dev_alive = build_alive_packet(
+        sender_end_id=e2e_creds["sender_end_id"],
+        sender_group_id=e2e_creds["sender_group_id"],
+        end_secret=e2e_creds["sender_end_secret"],
+    )
+    heartbeat = build_heartbeat_packet(e2e_creds, session_nonce)
+    wake = build_wake_packet(e2e_creds, session_nonce)
+    sub_pkt = build_subscription_packet(
+        e2e_creds, _RESERVE_CONFIG_GET_TYPE, session_nonce,
+    )
+
+    host, port = _resolve_host(e2e_creds["host"])
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    addr = (host, port)
+
+    def _send(pkt: bytes, label: str) -> bytes | None:
+        sock.sendto(pkt, addr)
+        try:
+            resp, _ = sock.recvfrom(4096)
+            if log:
+                log(f"{label}: sent {len(pkt)}B -> got {len(resp)}B")
+            return resp
+        except socket.timeout:
+            if log:
+                log(f"{label}: timeout")
+            return None
+
+    def _try(resp: bytes | None, label: str) -> dict | None:
+        if not resp:
+            return None
+        decrypted = decrypt_response(
+            resp, e2e_creds["chat_secret"],
+            payload_validator=_is_reserve_config_payload,
+            # Benign relay frames are not reserve-config payloads; silence the
+            # per-call decrypt failure flood.
+            silent=True,
+        )
+        if log:
+            log(f"0x5B {label}: " + (
+                f"{len(decrypted)}B = {decrypted.hex()}" if decrypted
+                else "did not decrypt / failed validation"))
+        return _parse_reserve_config(decrypted)
+
+    try:
+        _send(home_alive, "Alive(home)")
+        _send(dev_alive, "Alive(device)")
+        _send(wake, "Wake")
+        _send(heartbeat, "Heartbeat")
+        time.sleep(0.2)
+
+        result = _try(_send(sub_pkt, "Subscribe(0x5B)"), "subscribe response")
+        if result is not None:
+            return result
+
+        # The first response may not be the right type; try a few more.
+        for i in range(5):
+            try:
+                resp, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            result = _try(resp, f"drained frame {i + 1}")
+            if result is not None:
+                return result
+
+        if log:
+            log("read_reserve_mode_config: no frame validated as a 0x5B response")
+        return None
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# Scheduled-mode hour actions
+# ---------------------------------------------------------------------------
+#
+# A scheduled-mode hour carries a target percentage, not an on/off flag:
+#
+#     0         neither charge nor discharge
+#     1..100    charge up to N%
+#     0x80      no setting
+#     129..255  discharge down to (256-N)%
+#     101..127  not a valid value
+#
+# Verified live against the battery: five hours were each set to a different
+# option in the app and read back from opcode 0x18 with smart=25, emergency=10,
+# giving 100, 25, 10, 231, 246. Writing the same five back reproduced those bytes
+# and the app agreed.
+
+SLOT_NEITHER = 0
+SLOT_UNSET = 0x80
+SLOT_MAX_CHARGE = 100
+SLOT_MIN_DISCHARGE_RAW = 129
+
+ACTION_NEITHER = "neither"
+ACTION_CHARGE_TO_EMERGENCY = "charge_to_emergency"
+ACTION_CHARGE_TO_SMART = "charge_to_smart"
+ACTION_CHARGE_TO_FULL = "charge_to_full"
+ACTION_DISCHARGE_TO_SMART = "discharge_to_smart"
+ACTION_DISCHARGE_TO_EMERGENCY = "discharge_to_emergency"
+
+#: The five options the app offers, plus "neither".
+SCHEDULE_ACTIONS = (
+    ACTION_NEITHER,
+    ACTION_CHARGE_TO_EMERGENCY,
+    ACTION_CHARGE_TO_SMART,
+    ACTION_CHARGE_TO_FULL,
+    ACTION_DISCHARGE_TO_SMART,
+    ACTION_DISCHARGE_TO_EMERGENCY,
+)
+
+
+def charge_to_slot(pct: int) -> int:
+    """Wire value for "charge up to *pct*%"."""
+    if not 1 <= pct <= SLOT_MAX_CHARGE:
+        raise ValueError(f"A charge target must be 1-{SLOT_MAX_CHARGE}%, got {pct}.")
+    return pct
+
+
+def discharge_to_slot(pct: int) -> int:
+    """Wire value for "discharge down to *pct*%"."""
+    if not 1 <= pct <= SLOT_MAX_CHARGE:
+        raise ValueError(f"A discharge target must be 1-{SLOT_MAX_CHARGE}%, got {pct}.")
+    return 256 - pct
+
+
+def encode_slot(action: str | int, smart_pct: int, emergency_pct: int) -> int:
+    """Resolve one hour's action to its wire value.
+
+    *action* is either one of :data:`SCHEDULE_ACTIONS`, or an int: positive means
+    "charge up to N%", negative means "discharge down to N%".
+
+    The symbolic actions resolve against *smart_pct* / *emergency_pct*, which must
+    be the values going out in the SAME 0x19 write — not whatever the device holds
+    now. A write that changes the battery range and uses symbolic targets in the
+    same command must encode against the new range: verified live, where setting
+    80/20 encoded charge_to_smart as 80 rather than the device's previous 25.
+    """
+    if isinstance(action, bool):
+        raise ValueError(f"Invalid hour action: {action!r}")
+
+    if isinstance(action, int):
+        if action == 0:
+            return SLOT_NEITHER
+        return charge_to_slot(action) if action > 0 else discharge_to_slot(-action)
+
+    if action == ACTION_NEITHER:
+        return SLOT_NEITHER
+    if action == ACTION_CHARGE_TO_EMERGENCY:
+        return charge_to_slot(emergency_pct)
+    if action == ACTION_CHARGE_TO_SMART:
+        return charge_to_slot(smart_pct)
+    if action == ACTION_CHARGE_TO_FULL:
+        return charge_to_slot(100)
+    if action == ACTION_DISCHARGE_TO_SMART:
+        return discharge_to_slot(smart_pct)
+    if action == ACTION_DISCHARGE_TO_EMERGENCY:
+        return discharge_to_slot(emergency_pct)
+
+    raise ValueError(
+        f"Unknown hour action {action!r}; expected one of {SCHEDULE_ACTIONS}, "
+        "or an int (positive = charge to N%, negative = discharge to N%)."
+    )
+
+
+def encode_schedule_day(hour_actions: dict, smart_pct: int, emergency_pct: int) -> list[int]:
+    """Build 24 wire values from an ``{hour: action}`` mapping.
+
+    Hours not present are :data:`SLOT_NEITHER`.
+    """
+    slots = [SLOT_NEITHER] * 24
+    for hour, action in (hour_actions or {}).items():
+        hour = int(hour)
+        if not 0 <= hour <= 23:
+            raise ValueError(f"Hour must be 0-23, got {hour}.")
+        slots[hour] = encode_slot(action, smart_pct, emergency_pct)
+    return slots
+
+
+def describe_slot(raw: int, smart_pct: int, emergency_pct: int) -> str:
+    """Human description of a wire value, naming the symbolic target when it matches."""
+    if raw == SLOT_NEITHER:
+        return "neither"
+    if raw == SLOT_UNSET:
+        return "unset"
+
+    if 1 <= raw <= SLOT_MAX_CHARGE:
+        if raw == 100:
+            return "charge to 100%"
+        if raw == smart_pct:
+            return f"charge to smart ({raw}%)"
+        if raw == emergency_pct:
+            return f"charge to emergency ({raw}%)"
+        return f"charge to {raw}%"
+
+    if raw >= SLOT_MIN_DISCHARGE_RAW:
+        pct = 256 - raw
+        if pct == smart_pct:
+            return f"discharge to smart ({pct}%)"
+        if pct == emergency_pct:
+            return f"discharge to emergency ({pct}%)"
+        return f"discharge to {pct}%"
+
+    return f"invalid (0x{raw:02X})"
+
+
+def decode_schedule_day(slots: list[int], smart_pct: int, emergency_pct: int) -> dict:
+    """``{hour: description}`` for every hour that is not "neither"."""
+    return {
+        hour: describe_slot(raw, smart_pct, emergency_pct)
+        for hour, raw in enumerate(slots)
+        if raw != SLOT_NEITHER
+    }

--- a/custom_components/emaldo/services.py
+++ b/custom_components/emaldo/services.py
@@ -20,7 +20,14 @@ from .emaldo_lib.const import (
 )
 from .emaldo_lib.e2e import (
     EV_MODE_SCHEDULED,
+    RESERVE_MODE_SCHEDULED,
+    SCHEDULE_ACTIONS,
+    SLOT_NEITHER,
+    describe_slot,
+    encode_schedule_day,
+    read_reserve_mode_config,
     set_ev_charging_mode_smart,
+    set_reserve_mode,
 )
 from .emaldo_lib.exceptions import (
     EmaldoAuthError,
@@ -50,12 +57,77 @@ SERVICE_REFRESH_SCHEDULE = "refresh_schedule"
 SERVICE_SET_EV_SCHEDULE = "set_ev_schedule"
 SERVICE_BACKFILL_SOLAR = "backfill_solar"
 SERVICE_SET_BATTERY_RANGE = "set_battery_range"
+SERVICE_SET_SCHEDULED_MODE = "set_scheduled_mode"
+
+# Shared by set_ev_schedule and set_scheduled_mode: lists of hour integers 0-23
+# when the feature is active. Empty list or omitted key means "no hours selected".
+_SCHEMA_HOUR_LISTS = {
+    vol.Optional("weekdays", default=list): vol.All(
+        [vol.All(int, vol.Range(min=0, max=23))],
+    ),
+    vol.Optional("weekend", default=list): vol.All(
+        [vol.All(int, vol.Range(min=0, max=23))],
+    ),
+}
+
+
+def _hours_to_slots(hours: list[int]) -> list[int]:
+    """Expand a list of hour integers 0-23 into 24 per-hour 0/1 flags.
+
+    For set_ev_schedule, whose hours are packed into a bitmap where 1 simply means
+    "active". Scheduled mode does not use this: an hour there carries a target
+    percentage, so it goes through encode_schedule_day instead.
+    """
+    slots = [0] * 24
+    for h in hours:
+        slots[h] = 1
+    return slots
+
 
 SCHEMA_SET_BATTERY_RANGE = vol.Schema(
     {
         vol.Required("smart_pct"): vol.All(int, vol.Range(min=0, max=100)),
         vol.Required("emergency_pct"): vol.All(int, vol.Range(min=0, max=100)),
         vol.Optional("enable", default=True): cv.boolean,
+        vol.Optional("device_id"): cv.string,
+    }
+)
+
+# An hour is either one of the named actions or an int: positive charges up to
+# N%, negative discharges down to N%. Named actions follow the battery range,
+# which matters because that range changes.
+_SLOT_ACTION = vol.Any(
+    vol.In(SCHEDULE_ACTIONS),
+    vol.All(vol.Coerce(int), vol.Range(min=-100, max=100)),
+)
+
+#: ``{hour: action}``. YAML gives string keys, so coerce.
+_SCHEMA_HOUR_ACTIONS = vol.Schema(
+    {vol.All(vol.Coerce(int), vol.Range(min=0, max=23)): _SLOT_ACTION}
+)
+
+SCHEMA_SET_SCHEDULED_MODE = vol.Schema(
+    {
+        # Preferred: one action per hour, so discharge and per-hour targets are
+        # expressible. The device stores a target percentage per hour, not a flag.
+        vol.Optional("weekday_hours"): _SCHEMA_HOUR_ACTIONS,
+        vol.Optional("weekend_hours"): _SCHEMA_HOUR_ACTIONS,
+
+        # Deprecated shorthand: lists of hours to charge, all to the same target.
+        # Kept working, but it can only express charge - a third of the protocol.
+        **_SCHEMA_HOUR_LISTS,
+        vol.Optional("charge_pct", default=100): vol.All(int, vol.Range(min=1, max=100)),
+
+        # Deliberately no defaults: omitted means "leave the battery range as it
+        # is", which the handler resolves by reading the device. Defaulting here
+        # would silently reset a range the user set via set_battery_range, because
+        # smart/emergency ride along on every 0x19 write.
+        vol.Optional("smart_pct"): vol.All(int, vol.Range(min=0, max=100)),
+        vol.Optional("emergency_pct"): vol.All(int, vol.Range(min=0, max=100)),
+
+        # With sync on the device discards the weekend array entirely and the app
+        # derives the weekend from the weekday. Verified live.
+        vol.Optional("sync", default=True): cv.boolean,
         vol.Optional("device_id"): cv.string,
     }
 )
@@ -95,14 +167,7 @@ SCHEMA_APPLY_BULK_SCHEDULE = vol.Schema(
 
 SCHEMA_SET_EV_SCHEDULE = vol.Schema(
     {
-        # Lists of hour integers 0-23 when EV charging is allowed.
-        # Empty list or omitted key means "no hours selected".
-        vol.Optional("weekdays", default=list): vol.All(
-            [vol.All(int, vol.Range(min=0, max=23))],
-        ),
-        vol.Optional("weekend", default=list): vol.All(
-            [vol.All(int, vol.Range(min=0, max=23))],
-        ),
+        **_SCHEMA_HOUR_LISTS,
         vol.Optional("sync", default=False): cv.boolean,
         vol.Optional("device_id"): cv.string,
     }
@@ -850,12 +915,8 @@ async def async_handle_set_ev_schedule(
     sync = call.data.get("sync", False)
     device_id = call.data.get("device_id")
 
-    weekdays = [0] * 24
-    for h in weekday_hours:
-        weekdays[h] = 1
-    weekend = [0] * 24
-    for h in weekend_hours:
-        weekend[h] = 1
+    weekdays = _hours_to_slots(weekday_hours)
+    weekend = _hours_to_slots(weekend_hours)
 
     def _do_set():
         power_coord, client = _get_coordinator_and_client(
@@ -1148,6 +1209,160 @@ async def async_handle_set_battery_range(
                     await sched.async_request_refresh()
 
 
+async def async_handle_set_scheduled_mode(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Handle the set_scheduled_mode service call.
+
+    Switches the battery to Scheduled mode and writes the hourly schedule via E2E
+    opcode 0x19.
+
+    Preferred input is ``weekday_hours`` / ``weekend_hours``, an ``{hour: action}``
+    mapping. An hour is a target, not a flag, so the actions are:
+
+        neither, charge_to_emergency, charge_to_smart, charge_to_full,
+        discharge_to_smart, discharge_to_emergency
+
+    or an int - positive charges up to N%, negative discharges down to N%. Hours
+    left out are "neither".
+
+    The older ``weekdays`` / ``weekend`` hour lists with ``charge_pct`` still work
+    but can only express charging.
+
+    ``smart_pct``/``emergency_pct`` are optional: omit them to leave the battery
+    range untouched. They cannot be skipped on the wire - opcode 0x19 carries them
+    in bytes 2-3 on every write - so an omitted value is resolved by reading the
+    device first.
+
+    Note ``sync``: with it on, the device discards the weekend array and the app
+    shows the weekday schedule for both. Pass ``sync: false`` to set the weekend
+    independently.
+    """
+    smart = call.data.get("smart_pct")
+    emergency = call.data.get("emergency_pct")
+    sync = call.data.get("sync", True)
+    device_id = call.data.get("device_id")
+
+    weekday_actions = call.data.get("weekday_hours")
+    weekend_actions = call.data.get("weekend_hours")
+
+    if weekday_actions is None and weekend_actions is None:
+        # Deprecated path: hour lists, one shared charge target.
+        charge_pct = call.data.get("charge_pct", 100)
+        weekday_actions = {h: charge_pct for h in call.data.get("weekdays", [])}
+        weekend_actions = {h: charge_pct for h in call.data.get("weekend", [])}
+        if weekday_actions or weekend_actions:
+            _LOGGER.debug(
+                "set_scheduled_mode: using the deprecated weekdays/weekend lists; "
+                "weekday_hours/weekend_hours can also express discharge"
+            )
+    else:
+        weekday_actions = weekday_actions or {}
+        weekend_actions = weekend_actions or {}
+
+    # Filled in by _do_set: the range actually written, and the encoded hours, so
+    # the log line below describes what went on the wire instead of re-deriving it.
+    written: dict[str, Any] = {}
+
+    def _do_set():
+        power_coord, client = _get_coordinator_and_client(
+            hass, coordinator_key="power", device_id=device_id
+        )
+        for attempt in range(2):
+            try:
+                creds = client.e2e_login(
+                    power_coord.home_id,
+                    power_coord._device_id,  # noqa: SLF001
+                    power_coord._model,      # noqa: SLF001
+                )
+                write_smart, write_emergency = smart, emergency
+                if write_smart is None or write_emergency is None:
+                    # The range must come from 0x5B. It is carried in bytes 2-3 of
+                    # every 0x19 write, so an omitted value has to be resolved
+                    # rather than defaulted - defaulting would overwrite whatever
+                    # the user set via set_battery_range.
+                    current = read_reserve_mode_config(creds)
+                    if current is None:
+                        raise EmaldoE2EError(
+                            "Could not read the current battery range (opcode 0x5B), "
+                            "so set_scheduled_mode would have to guess it. Pass "
+                            "smart_pct and emergency_pct explicitly, or retry."
+                        )
+                    if write_smart is None:
+                        write_smart = current["smart"]
+                    if write_emergency is None:
+                        write_emergency = current["emergency"]
+
+                # Encode only now. charge_to_smart must resolve against the range
+                # being written in THIS command, not whatever the device held
+                # before: a call that changes the range and uses symbolic targets
+                # would otherwise encode against the old one.
+                weekday_slots = encode_schedule_day(
+                    weekday_actions, write_smart, write_emergency
+                )
+                weekend_slots = encode_schedule_day(
+                    weekend_actions, write_smart, write_emergency
+                )
+
+                written.update(
+                    smart=write_smart,
+                    emergency=write_emergency,
+                    weekday_slots=weekday_slots,
+                    weekend_slots=weekend_slots,
+                )
+                return set_reserve_mode(
+                    creds, RESERVE_MODE_SCHEDULED,
+                    weekday_slots=weekday_slots,
+                    weekend_slots=weekend_slots,
+                    smart_pct=write_smart, emergency_pct=write_emergency,
+                    sync=sync,
+                )
+            except EmaldoAuthError:
+                if attempt == 0:
+                    _LOGGER.debug("Session expired, re-authenticating")
+                    power_coord._reset_client()  # noqa: SLF001
+                else:
+                    raise
+
+    ok = await hass.async_add_executor_job(_do_set)
+    if ok:
+        write_smart = written["smart"]
+        write_emergency = written["emergency"]
+
+        def _describe(slots: list[int]) -> dict[int, str]:
+            return {
+                hour: describe_slot(raw, write_smart, write_emergency)
+                for hour, raw in enumerate(slots)
+                if raw != SLOT_NEITHER
+            }
+
+        weekday_desc = _describe(written["weekday_slots"])
+        weekend_desc = (
+            "mirrored from weekday (sync on)"
+            if sync
+            else _describe(written["weekend_slots"])
+        )
+        _LOGGER.info(
+            "Scheduled mode set: smart=%d%%, emergency=%d%%, sync=%s, weekday=%s, weekend=%s",
+            write_smart, write_emergency, sync, weekday_desc, weekend_desc,
+        )
+    else:
+        _LOGGER.warning("Scheduled mode write was not acknowledged")
+
+    # Refresh the schedule coordinator so the new plan reaches the sensors.
+    if device_id:
+        target_set = _get_target_set(
+            hass, coordinator_key="schedule", device_id=device_id
+        )
+        await target_set["schedule"].async_request_refresh()
+    else:
+        for entry_data in _get_entry_data(hass).values():
+            for item in _iter_device_sets(entry_data):
+                sched = item.get("schedule")
+                if sched is not None:
+                    await sched.async_request_refresh()
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register Emaldo services."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_SLOT_RANGE):
@@ -1173,6 +1388,9 @@ def async_register_services(hass: HomeAssistant) -> None:
 
     async def handle_set_battery_range(call: ServiceCall) -> None:
         await async_handle_set_battery_range(hass, call)
+
+    async def handle_set_scheduled_mode(call: ServiceCall) -> None:
+        await async_handle_set_scheduled_mode(hass, call)
 
     hass.services.async_register(
         DOMAIN,
@@ -1216,6 +1434,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         handle_set_battery_range,
         schema=SCHEMA_SET_BATTERY_RANGE,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_SCHEDULED_MODE,
+        handle_set_scheduled_mode,
+        schema=SCHEMA_SET_SCHEDULED_MODE,
+    )
 
 
 def async_unregister_services(hass: HomeAssistant) -> None:
@@ -1228,3 +1452,4 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         hass.services.async_remove(DOMAIN, SERVICE_SET_EV_SCHEDULE)
         hass.services.async_remove(DOMAIN, SERVICE_BACKFILL_SOLAR)
         hass.services.async_remove(DOMAIN, SERVICE_SET_BATTERY_RANGE)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_SCHEDULED_MODE)

--- a/custom_components/emaldo/services.yaml
+++ b/custom_components/emaldo/services.yaml
@@ -170,6 +170,89 @@ backfill_solar:
           max: 90
           step: 1
 
+set_scheduled_mode:
+  name: Set scheduled mode
+  description: >
+    Switch the battery to Scheduled mode and write the hourly schedule
+    (E2E opcode 0x19). An hour carries a target percentage, not an on/off
+    flag, so each hour is set to one of six actions.
+  fields:
+    weekday_hours:
+      name: Weekday hours
+      description: >
+        Map of hour (0-23) to action. Actions: neither, charge_to_emergency,
+        charge_to_smart, charge_to_full, discharge_to_smart,
+        discharge_to_emergency. An integer also works - positive charges up to
+        N%, negative discharges down to N%. Hours left out are "neither".
+        The named actions follow the battery range, so they stay correct when
+        that range changes.
+      example: "{1: charge_to_full, 2: charge_to_smart, 18: discharge_to_emergency}"
+      selector:
+        object:
+    weekend_hours:
+      name: Weekend hours
+      description: >
+        Same format as weekday_hours. Only has an effect when sync is off -
+        with sync on the battery discards the weekend schedule and uses the
+        weekday one for every day.
+      example: "{9: discharge_to_smart, 10: discharge_to_smart}"
+      selector:
+        object:
+    sync:
+      name: Sync weekday/weekend
+      description: >
+        On: the battery ignores weekend_hours and applies the weekday schedule
+        to the whole week. Off: weekday and weekend are stored separately.
+      default: true
+      selector:
+        boolean:
+    smart_pct:
+      name: Smart reserve %
+      description: >
+        Upper SoC threshold. Leave empty to keep the battery's current setting -
+        opcode 0x19 always carries this value, so it is read from the device
+        rather than defaulted. When set, charge_to_smart and discharge_to_smart
+        in the same call resolve to this new value.
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    emergency_pct:
+      name: Emergency reserve %
+      description: >
+        Lower SoC threshold. Leave empty to keep the battery's current setting.
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    weekdays:
+      name: Weekday charge hours (deprecated)
+      description: >
+        Deprecated. List of hours to charge, all to the same charge_pct target.
+        Cannot express discharge or per-hour targets; use weekday_hours instead.
+      example: "[0, 1, 2, 3, 4, 5]"
+      selector:
+        object:
+    weekend:
+      name: Weekend charge hours (deprecated)
+      description: Deprecated. Use weekend_hours instead.
+      example: "[0, 1, 2, 3, 4, 5]"
+      selector:
+        object:
+    charge_pct:
+      name: Charge target % (deprecated)
+      description: >
+        Deprecated. The charge target used for every hour listed in the
+        weekdays/weekend lists.
+      default: 100
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
+
 set_battery_range:
   name: Set AI Battery Range
   description: >

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -373,14 +373,46 @@ All payloads are little-endian unless noted.
 | 0–1 | `u16` | `state` | 0=Idle,1=OnHold,2=FcrN,3=FcrDUp,4=FcrDDown,5=FcrDUpDown,6=MFRRUp,7=MFRRDown |
 | 2–3 | `u16` | `error_flag` | present in 4-byte variant; `≠1` means error |
 
-### 7.5 Peak Shaving Config (`0x5B`, 20 bytes)
+### 7.5 Reserve Mode Config (`0x5B`, 20 bytes)
 
-| Offset | Type | Field |
-|--------|------|-------|
-| 0 | `u8` | `enabled` |
-| 5 | `u8` | `peak_reserve_pct` |
-| 6 | `u8` | `ups_reserve_pct` |
-| 18 | `u8` | `redundancy` |
+Previously documented here as "Peak Shaving Config". The 20-byte response actually
+carries the reserve-mode configuration. Established by observation against a real
+battery rather than from the APK: the range was changed in the app and bytes 15
+and 17 followed it exactly, twice (63/25 → 55/30 → 25/10), in plain binary.
+
+| Offset | Type | Field | Notes |
+|--------|------|-------|-------|
+| 0–6 | — | — | Always zero so far |
+| 7–10 | `u32` | `full_charge_wh` | Full charge capacity, Wh, LE |
+| 11–14 | `u32` | — | Static, meaning unknown. Not current energy — stayed at 7128 while SoC was 54% of 15288 |
+| 15 | `u8` | `emergency_pct` | Lower (emergency) reserve % |
+| 16 | `u8` | — | Always 100 so far. Not `plenty_reserve`, which is 98 |
+| 17 | `u8` | `smart_pct` | Upper (smart) reserve % |
+| 18 | `u8` | `reserve_mode` | 1 = price tracking, 2 = scheduled, 3 = AI adapter |
+| 19 | `u8` | `enabled` | |
+
+**The only read that reports the current reserve mode.** For the battery range it
+agrees with `0x18`, so the two can be cross-checked.
+
+### 7.5b Scheduled Mode Schedule (`0x18`, 57 bytes)
+
+`get_schedule_reservemode` — the scheduled-mode hourly schedule *and* the battery
+range. Layout per the APK callback (`module_bmt/zd/q0.java`), confirmed live.
+
+| Offset | Type | Field | Notes |
+|--------|------|-------|-------|
+| 0 | `u8` | `smart_pct` | Genuinely the range here, unlike `0x46` |
+| 1 | `u8` | `emergency_pct` | |
+| 2 | `u8` | `lowpower_alert` | |
+| 3 | `u8` | `battery_protect` | |
+| 4–27 | `u8[24]` | `weekday_hours` | One per hour; see §8b |
+| 28–51 | `u8[24]` | `weekend_hours` | Read back as zeros when `sync` is set |
+| 52 | `u8` | `sync` | 1 = device stores weekday only |
+| 53–56 | `u32` | `full_charge_wh` | LE |
+
+Not to be confused with `get_custom_schedulemode` (`0x46`, 58 bytes), a separate
+block that reads back `0x80` for every hour regardless of the app's setting, and
+whose bytes 0–1 are a fixed header (`0x50 0x0F`) rather than the battery range.
 
 ### 7.6 Peak Schedule (`0x5C`, ≥16 bytes)
 
@@ -457,6 +489,56 @@ Constants in `const.py`:
 - `SLOT_IDLE = 0x00`
 - `SLOT_CHARGE_DEFAULT = 0x48` (charge when SoC < 72%)
 - `DEFAULT_MARKER_HIGH = 72`, `DEFAULT_MARKER_LOW = 20`
+
+---
+
+## 8b. Scheduled Mode Hour Values
+
+24 hours per day type (weekday / weekend), one byte each. An hour carries a
+**target percentage**, not an on/off flag.
+
+| Value | Meaning |
+|-------|---------|
+| `0x00` (0) | Neither charge nor discharge |
+| 1–100 | Charge up to N% |
+| `0x80` (128) | No setting |
+| 129–255 | Discharge down to (256 − N)% |
+| 101–127 | Not a valid value |
+
+Verified live: five hours were each set to a different option in the app and read
+back from `0x18` with smart=25, emergency=10, giving `100 25 10 231 246`. Writing
+the same five back reproduced those bytes and the app agreed.
+
+The six named actions in `e2e.py` (`SCHEDULE_ACTIONS`) resolve against the battery
+range **being written in the same `0x19` command**, not the range currently on the
+device — confirmed by writing 80/20 while the device held 25/10, which encoded
+`charge_to_smart` as 80.
+
+---
+
+## 8c. `0x19` set_reservemode (54 bytes)
+
+APK dispatch-table case 43 (`'+'`). Subscribe mode.
+
+| Offset | Type | Field | Notes |
+|--------|------|-------|-------|
+| 0 | `u8` | `mode - 1` | 0 = price tracking, 1 = scheduled, 2 = AI adapter |
+| 1 | `u8` | `clear_flag` | 1 wipes the schedule; set only when scheduled mode is sent with no slot data |
+| 2 | `u8` | `smart_pct` | Carried on **every** write — see below |
+| 3 | `u8` | `emergency_pct` | |
+| 4–27 | `u8[24]` | `weekday_hours` | §8b encoding |
+| 28–51 | `u8[24]` | `weekend_hours` | Discarded by the device when `sync` = 1 |
+| 52 | `u8` | `sync` | |
+| 53 | `u8` | `enable` | |
+
+Because bytes 2–3 ride along on every write, a caller that does not mean to change
+the battery range must read the current value (`0x5B` or `0x18`) and send it back.
+`set_reserve_mode` therefore takes `smart_pct`/`emergency_pct` as required
+arguments with no defaults.
+
+`sync` is authoritative over the weekend array: with it set, the device discards
+bytes 28–51 (`0x18` reads them back as zeros) and the app derives the weekend from
+the weekday.
 
 ---
 


### PR DESCRIPTION
Adds **Scheduled mode** (reserve mode 2) as a service, plus the two E2E reads it needs.

Scheduled mode is the battery's own hourly plan — the one set in the app under Battery Strategies. Until now the integration could only drive the AI override plan (`0x1A`), which is a different control surface, so a battery running in Scheduled mode couldn't be controlled from Home Assistant at all.

Based on `v1.0.0-beta27` as requested. No `CHANGES.md` entry and no `manifest.json` bump — left to you for release.

## New service: `emaldo.set_scheduled_mode`

Writes the hourly schedule over opcode `0x19`.

A scheduled-mode hour carries a **target percentage**, not an on/off flag, so each hour takes one of six actions — `neither`, `charge_to_emergency`, `charge_to_smart`, `charge_to_full`, `discharge_to_smart`, `discharge_to_emergency` — or a raw int, where positive charges up to N% and negative discharges down to N%.

```yaml
service: emaldo.set_scheduled_mode
data:
  weekday_hours:
    0: charge_to_full
    1: charge_to_full
    17: discharge_to_emergency
    18: discharge_to_emergency
  sync: true
```

Two behaviours worth calling out:

- **The named actions resolve against the range being written in the same command.** Changing `smart_pct` and using `charge_to_smart` in one call encodes against the new value, not the device's previous one.
- **`smart_pct`/`emergency_pct` are optional and are never defaulted.** Bytes 2–3 of every `0x19` write carry the range, so an omitted value is resolved by reading `0x5B` and sent back unchanged. Defaulting them would silently overwrite a range the user set via `set_battery_range`.

`sync` defaults to `true`, matching the app: the device then discards the weekend array and mirrors the weekday schedule across the week.

## New reads

| Opcode | Function | Returns |
|---|---|---|
| `0x18` | `read_schedule_mode` | `get_schedule_reservemode` — the hourly schedule and the battery range |
| `0x5B` | `read_reserve_mode_config` | The battery range plus the **current reserve mode**, which no other read reports |

Exposed on `EmaldoClient` as `get_schedule_mode` and `set_reserve_mode`.

## Protocol corrections

Three things looked right from the APK alone but turned out otherwise. All were established against a real battery, and `docs/PROTOCOL.md` is updated to match.

- **The schedule is in `0x18`, not `0x46`.** `0x46` (`get_custom_schedulemode`) reads back `0x80` for every hour regardless of what the app shows, and its bytes 0–1 are a fixed header (`0x50 0x0F`) rather than smart/emergency.
- **Hour values are targets, not flags.** Verified by setting five hours to each of the app's options and reading `0x18` back with smart=25, emergency=10 — giving `100 25 10 231 246`. Writing the same five back reproduced those bytes and the app agreed.
- **`0x5B` is the reserve-mode configuration, not peak shaving.** Established by changing the range in the app and watching bytes 15 and 17 follow it, twice (63/25 → 55/30 → 25/10). `PROTOCOL.md` §7.5 is corrected; the old field names (`peak_reserve_pct`, `ups_reserve_pct`, `redundancy`) didn't correspond to anything the device sends.

## On the payload validators

`_is_schedule_mode_payload` and `_is_reserve_config_payload` do more work than sanity checks normally would, and it's deliberate: `decrypt_response` brute-forces the AES IV and every 16-aligned tail offset and returns the **first** candidate a validator accepts. So the validator is what *selects* the decryption, not what checks it afterwards. A loose check picks wrong-offset garbage that unpads cleanly and parses as an empty schedule with nonsense thresholds.

Hence they constrain every field the documented layout pins down, and require an exact payload length — the offset search yields nested candidates that are suffixes of each other (57, 74, 90, 106 bytes …), so `>= 57` would accept a longer one whose first 57 bytes happen to fit.

## Testing

- All 16 scenarios of the encoding — every hour action, both day types, the boundaries, and range changes — were run live against a PS1-BAK10-HS10 and confirmed in the Emaldo app one at a time, each reverted afterwards. The device finished byte-identical to the pre-run snapshot.
- `sync` behaviour confirmed live: with it on, contradictory weekday/weekend arrays result in the weekend being discarded and the app showing weekday for both.
- Symbolic resolution confirmed by writing 80/20 while the device held 25/10 and checking the hour targets came out as `80 20 176 236`.

Note the service handler itself has been exercised through the library, not yet inside a running Home Assistant — worth a look on your side before merge.

## Docs

- `README.md` — service reference under `## Services`, with two examples.
- `docs/PROTOCOL.md` — §7.5 corrected, plus new §7.5b (`0x18` layout), §8b (hour values) and §8c (`0x19` command).
